### PR TITLE
Add Makefile with build convenience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+vtop

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+CC := gcc
+CFLAGS := -Wall -O2 -Iinclude
+
+SRC := src/main.c
+BIN := vtop
+
+all: $(BIN)
+
+$(BIN): $(SRC)
+	$(CC) $(CFLAGS) $< -o $@
+
+run: $(BIN)
+	./$(BIN)
+
+clean:
+	$(RM) $(BIN)
+
+.PHONY: all run clean


### PR DESCRIPTION
## Summary
- add Makefile for building `vtop`
- ignore built binary in `.gitignore`

## Testing
- `make clean`
- `make all`
- `make run`

------
https://chatgpt.com/codex/tasks/task_e_6854a63484ec8324b92ee027424c5e73