### PR TITLE
Add optional ncurses UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,18 @@
 CC := gcc
 CFLAGS := -Wall -O2 -Iinclude
-
 SRC := src/main.c src/proc.c
 BIN := vtop
+
+ifdef WITH_UI
+CFLAGS += -DWITH_UI
+SRC += src/ui.c
+LDLIBS += -lncurses
+endif
 
 all: $(BIN)
 
 $(BIN): $(SRC)
-	$(CC) $(CFLAGS) $(SRC) -o $@
+	$(CC) $(CFLAGS) $(SRC) $(LDLIBS) -o $@
 
 run: $(BIN)
 	./$(BIN)

--- a/README.md
+++ b/README.md
@@ -6,3 +6,12 @@ Compile with gcc:
 ```sh
 gcc src/main.c -Iinclude -o vtop
 ```
+
+### With ncurses UI
+To build the interactive view using `ncurses`, enable the `WITH_UI` flag:
+```sh
+make WITH_UI=1
+```
+Otherwise, running `make` will build a simple command-line version
+that prints the version number.
+

--- a/include/ui.h
+++ b/include/ui.h
@@ -1,0 +1,6 @@
+#ifndef UI_H
+#define UI_H
+
+int run_ui(void);
+
+#endif /* UI_H */

--- a/src/main.c
+++ b/src/main.c
@@ -1,10 +1,14 @@
 #include <stdio.h>
 #include "version.h"
+#ifdef WITH_UI
+#include "ui.h"
+#endif
 
 int main(void) {
-#ifdef _POSIX_VERSION
-    /* Placeholder for future POSIX-specific code */
-#endif
+#ifdef WITH_UI
+    return run_ui();
+#else
     printf("vtop version %s\n", VTOP_VERSION);
     return 0;
+#endif
 }

--- a/src/ui.c
+++ b/src/ui.c
@@ -1,0 +1,35 @@
+#include "proc.h"
+#ifdef WITH_UI
+#include <ncurses.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#define MAX_PROC 256
+
+int run_ui(void) {
+    initscr();
+    cbreak();
+    noecho();
+    keypad(stdscr, TRUE);
+    nodelay(stdscr, TRUE);
+
+    struct process_info procs[MAX_PROC];
+
+    int ch = 0;
+    while (ch != 'q') {
+        size_t count = list_processes(procs, MAX_PROC);
+        erase();
+        mvprintw(0, 0, "PID      NAME                     STATE  VSIZE    RSS");
+        for (size_t i = 0; i < count && i < LINES - 2; i++) {
+            mvprintw(i + 1, 0, "%-8d %-25s %c %8llu %5ld",
+                     procs[i].pid, procs[i].name, procs[i].state,
+                     procs[i].vsize, procs[i].rss);
+        }
+        refresh();
+        usleep(500000); /* half a second */
+        ch = getch();
+    }
+    endwin();
+    return 0;
+}
+#endif /* WITH_UI */


### PR DESCRIPTION
## Summary
- add ncurses based UI with simple keyboard controls
- hook up build system to optionally compile UI code
- document optional UI build flag in README

## Testing
- `make WITH_UI=1`
- `make`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_6854b967ff408324af37fffecb932ede