### PR TITLE
Add build directory and editor artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,15 @@ Module.symvers
 Mkfile.old
 dkms.conf
 vtop
+
+# Build directories
+build/
+
+# OS and editor artifacts
+.DS_Store
+Thumbs.db
+*~
+*.swp
+*.swo
+.idea/
+.vscode/


### PR DESCRIPTION
## Summary
- list build directory and editor/OS temp files in `.gitignore`

## Testing
- `make`
- `make WITH_UI=1`


------
https://chatgpt.com/codex/tasks/task_e_6854cdc4d6ac8324bff5bc1380cee06c