### PR TITLE
Add getopt options and docs

### DIFF
--- a/include/ui.h
+++ b/include/ui.h
@@ -1,6 +1,13 @@
 #ifndef UI_H
 #define UI_H
 
-int run_ui(void);
+enum sort_field {
+    SORT_PID,
+    SORT_NAME,
+    SORT_VSIZE,
+    SORT_RSS
+};
+
+int run_ui(unsigned int delay_ms, enum sort_field sort);
 
 #endif /* UI_H */

--- a/src/main.c
+++ b/src/main.c
@@ -1,13 +1,48 @@
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 #include "version.h"
-#ifdef WITH_UI
 #include "ui.h"
-#endif
 
-int main(void) {
+static void usage(const char *prog) {
+    printf("Usage: %s [-d seconds] [-s column]\n", prog);
+    printf("  -d SECS   Refresh delay in seconds (default 3)\n");
+    printf("  -s COL    Sort column: pid,name,vsize,rss (default pid)\n");
+}
+
+int main(int argc, char *argv[]) {
+    unsigned int delay_ms = 3000; /* default 3 seconds */
+    enum sort_field sort = SORT_PID;
+
+    int opt;
+    while ((opt = getopt(argc, argv, "d:s:h")) != -1) {
+        switch (opt) {
+        case 'd':
+            delay_ms = (unsigned int)(strtod(optarg, NULL) * 1000);
+            break;
+        case 's':
+            if (strcmp(optarg, "name") == 0)
+                sort = SORT_NAME;
+            else if (strcmp(optarg, "vsize") == 0)
+                sort = SORT_VSIZE;
+            else if (strcmp(optarg, "rss") == 0)
+                sort = SORT_RSS;
+            else
+                sort = SORT_PID;
+            break;
+        case 'h':
+        default:
+            usage(argv[0]);
+            return 0;
+        }
+    }
+
 #ifdef WITH_UI
-    return run_ui();
+    return run_ui(delay_ms, sort);
 #else
+    (void)delay_ms; /* unused */
+    (void)sort;     /* unused */
     printf("vtop version %s\n", VTOP_VERSION);
     return 0;
 #endif

--- a/src/ui.c
+++ b/src/ui.c
@@ -1,12 +1,36 @@
 #include "proc.h"
+#include "ui.h"
 #ifdef WITH_UI
 #include <ncurses.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 #define MAX_PROC 256
 
-int run_ui(void) {
+static enum sort_field current_sort;
+
+static int compare_procs(const void *a, const void *b) {
+    const struct process_info *pa = a;
+    const struct process_info *pb = b;
+    switch (current_sort) {
+    case SORT_PID:
+        return pa->pid - pb->pid;
+    case SORT_NAME:
+        return strcmp(pa->name, pb->name);
+    case SORT_VSIZE:
+        if (pa->vsize < pb->vsize) return 1;
+        if (pa->vsize > pb->vsize) return -1;
+        return 0;
+    case SORT_RSS:
+        if (pa->rss < pb->rss) return 1;
+        if (pa->rss > pb->rss) return -1;
+        return 0;
+    }
+    return 0;
+}
+
+int run_ui(unsigned int delay_ms, enum sort_field sort) {
     initscr();
     cbreak();
     noecho();
@@ -15,9 +39,11 @@ int run_ui(void) {
 
     struct process_info procs[MAX_PROC];
 
+    current_sort = sort;
     int ch = 0;
     while (ch != 'q') {
         size_t count = list_processes(procs, MAX_PROC);
+        qsort(procs, count, sizeof(struct process_info), compare_procs);
         erase();
         mvprintw(0, 0, "PID      NAME                     STATE  VSIZE    RSS");
         for (size_t i = 0; i < count && i < LINES - 2; i++) {
@@ -26,7 +52,7 @@ int run_ui(void) {
                      procs[i].vsize, procs[i].rss);
         }
         refresh();
-        usleep(500000); /* half a second */
+        usleep(delay_ms * 1000);
         ch = getch();
     }
     endwin();

--- a/vtopdoc.md
+++ b/vtopdoc.md
@@ -24,3 +24,20 @@ robust.
 
 These functions provide a lightweight interface for higher level
 monitoring tools without requiring additional dependencies.
+
+## Command-line Options
+
+`vtop` accepts a few options similar to classic `top`.
+
+- `-d SECS` &mdash; Set the refresh delay in seconds. The default is
+  `3` seconds just like `top`.
+- `-s COL` &mdash; Choose the column to sort by. Supported values are
+  `pid`, `name`, `vsize` and `rss`. The default is `pid`.
+
+Examples:
+
+```sh
+vtop              # run with defaults (3s delay, sort by pid)
+vtop -d 1         # update every second
+vtop -s rss       # sort processes by resident set size
+```


### PR DESCRIPTION
## Summary
- add `-d` and `-s` options using getopt
- accept sort field enum in UI
- document command line options in `vtopdoc.md`

## Testing
- `make clean && make WITH_UI=1`

------
https://chatgpt.com/codex/tasks/task_e_6854daf5c2388324bb439691ca605b4b