### PR TITLE
Add system stats summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,12 @@ The `-s` option selects the sort field. Available values are:
 When running the ncurses interface you can press `F3` or `>` to cycle to
 the next sort field and `<` to go back.
 
+Example output with the ncurses interface:
+
+```text
+$ vtop
+load 0.00 0.01 0.05  up 1234s  tasks 1/87  cpu 2.0%  mem 27.3%
+PID      NAME                     STATE  VSIZE    RSS  RSS%  CPU%
+...
+```
+

--- a/include/proc.h
+++ b/include/proc.h
@@ -22,6 +22,15 @@ struct mem_stats {
     unsigned long long cached;
 };
 
+struct misc_stats {
+    double load1;
+    double load5;
+    double load15;
+    double uptime;
+    int running_tasks;
+    int total_tasks;
+};
+
 struct process_info {
     int pid;
     char name[256];
@@ -40,6 +49,7 @@ struct process_info {
 int read_cpu_stats(struct cpu_stats *stats);
 int read_mem_stats(struct mem_stats *stats);
 size_t list_processes(struct process_info *buf, size_t max);
+int read_misc_stats(struct misc_stats *stats);
 
 /* comparison helpers for sorting */
 int cmp_proc_pid(const void *a, const void *b);

--- a/src/proc.c
+++ b/src/proc.c
@@ -165,6 +165,37 @@ size_t list_processes(struct process_info *buf, size_t max) {
     return count;
 }
 
+int read_misc_stats(struct misc_stats *stats) {
+    FILE *fp = fopen("/proc/loadavg", "r");
+    if (!fp)
+        return -1;
+    double l1 = 0.0, l5 = 0.0, l15 = 0.0;
+    int running = 0, total = 0;
+    if (fscanf(fp, "%lf %lf %lf %d/%d", &l1, &l5, &l15, &running, &total) < 5) {
+        fclose(fp);
+        return -1;
+    }
+    fclose(fp);
+
+    fp = fopen("/proc/uptime", "r");
+    if (!fp)
+        return -1;
+    double up = 0.0;
+    if (fscanf(fp, "%lf", &up) != 1) {
+        fclose(fp);
+        return -1;
+    }
+    fclose(fp);
+
+    stats->load1 = l1;
+    stats->load5 = l5;
+    stats->load15 = l15;
+    stats->uptime = up;
+    stats->running_tasks = running;
+    stats->total_tasks = total;
+    return 0;
+}
+
 int cmp_proc_pid(const void *a, const void *b) {
     const struct process_info *pa = a;
     const struct process_info *pb = b;

--- a/src/ui.c
+++ b/src/ui.c
@@ -8,6 +8,9 @@
 
 #define MAX_PROC 256
 
+static unsigned long long prev_total;
+static unsigned long long prev_idle;
+
 static enum sort_field current_sort;
 static int (*compare_procs)(const void *, const void *) = cmp_proc_pid;
 
@@ -34,16 +37,42 @@ int run_ui(unsigned int delay_ms, enum sort_field sort) {
     nodelay(stdscr, TRUE);
 
     struct process_info procs[MAX_PROC];
+    struct cpu_stats cs;
+    struct mem_stats ms;
+    struct misc_stats misc;
+    double cpu_usage = 0.0;
+    double mem_usage = 0.0;
 
     set_sort(sort);
     int ch = 0;
     while (ch != 'q') {
+        if (read_cpu_stats(&cs) == 0) {
+            unsigned long long idle = cs.idle + cs.iowait;
+            unsigned long long total = cs.user + cs.nice + cs.system +
+                                       cs.irq + cs.softirq + cs.steal + idle;
+            unsigned long long d_total = total - prev_total;
+            unsigned long long d_idle = idle - prev_idle;
+            if (d_total > 0)
+                cpu_usage = 100.0 * (double)(d_total - d_idle) / (double)d_total;
+            prev_total = total;
+            prev_idle = idle;
+        }
+        if (read_mem_stats(&ms) == 0 && ms.total > 0) {
+            unsigned long long used = ms.total - ms.available;
+            mem_usage = 100.0 * (double)used / (double)ms.total;
+        }
+        read_misc_stats(&misc);
+
         size_t count = list_processes(procs, MAX_PROC);
         qsort(procs, count, sizeof(struct process_info), compare_procs);
         erase();
-        mvprintw(0, 0, "%s", "PID      NAME                     STATE  VSIZE    RSS  RSS%  CPU%");
-        for (size_t i = 0; i < count && i < LINES - 2; i++) {
-            mvprintw(i + 1, 0, "%-8d %-25s %c %8llu %5ld %6.2f %6.2f",
+        mvprintw(0, 0,
+                 "load %.2f %.2f %.2f  up %.0fs  tasks %d/%d  cpu %5.1f%%  mem %5.1f%%",
+                 misc.load1, misc.load5, misc.load15, misc.uptime,
+                 misc.running_tasks, misc.total_tasks, cpu_usage, mem_usage);
+        mvprintw(1, 0, "%s", "PID      NAME                     STATE  VSIZE    RSS  RSS%  CPU%");
+        for (size_t i = 0; i < count && i < LINES - 3; i++) {
+            mvprintw(i + 2, 0, "%-8d %-25s %c %8llu %5ld %6.2f %6.2f",
                      procs[i].pid, procs[i].name, procs[i].state,
                      procs[i].vsize, procs[i].rss,
                      procs[i].rss_percent, procs[i].cpu_usage);

--- a/vtopdoc.md
+++ b/vtopdoc.md
@@ -15,6 +15,12 @@ softirq and steal.
 `MemTotal`, `MemFree` and `MemAvailable`. Values are read line by line
 with simple string matching, allowing the code to remain portable.
 
+## Miscellaneous Statistics
+`read_misc_stats()` parses `/proc/loadavg` and `/proc/uptime` to obtain
+load averages, total running tasks and system uptime. The function fills
+a `struct misc_stats` with three load values, the uptime in seconds and
+the number of running versus total tasks.
+
 ## Running Processes
 `list_processes()` iterates through numeric directories in `/proc`.
 For each process it reads the corresponding `/proc/[pid]/stat` file to


### PR DESCRIPTION
## Summary
- add `read_misc_stats` for load averages and uptime
- show system stats in ncurses UI header
- document the new functionality and show example output

## Testing
- `make WITH_UI=1`

------
https://chatgpt.com/codex/tasks/task_e_6854e0cf12048324b78bf1db3470ae87