### PR TITLE
Add kill and renice controls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC := gcc
 CFLAGS := -Wall -O2 -Iinclude
-SRC := src/main.c src/proc.c
+SRC := src/main.c src/proc.c src/control.c
 BIN := vtop
 
 ifdef WITH_UI

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ The `-s` option selects the sort field. Available values are:
 When running the ncurses interface you can press `F3` or `>` to cycle to
 the next sort field and `<` to go back.
 
+Additional shortcuts:
+
+- Press `k` to send `SIGTERM` to a process. vtop will prompt for the PID.
+- Press `r` to change a process's nice value. You will be asked for the
+  PID and the new nice level.
+
+These controls operate on live processes. Ensure you have permission to
+signal or renice the target process. Running as root can terminate or slow
+critical system tasks, so use with care.
+
 Example output with the ncurses interface:
 
 ```text

--- a/include/control.h
+++ b/include/control.h
@@ -1,0 +1,7 @@
+#ifndef CONTROL_H
+#define CONTROL_H
+
+int send_signal(int pid, int sig);
+int change_priority(int pid, int niceval);
+
+#endif /* CONTROL_H */

--- a/src/control.c
+++ b/src/control.c
@@ -1,0 +1,11 @@
+#include "control.h"
+#include <signal.h>
+#include <sys/resource.h>
+
+int send_signal(int pid, int sig) {
+    return kill(pid, sig);
+}
+
+int change_priority(int pid, int niceval) {
+    return setpriority(PRIO_PROCESS, pid, niceval);
+}

--- a/src/ui.c
+++ b/src/ui.c
@@ -1,10 +1,12 @@
 #include "proc.h"
 #include "ui.h"
+#include "control.h"
 #ifdef WITH_UI
 #include <ncurses.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <signal.h>
 
 #define MAX_PROC 256
 
@@ -91,6 +93,34 @@ int run_ui(unsigned int delay_ms, enum sort_field sort) {
                 set_sort(SORT_MEM);
             else
                 set_sort(current_sort - 1);
+        } else if (ch == 'k') {
+            char buf[16];
+            nodelay(stdscr, FALSE);
+            echo();
+            curs_set(1);
+            mvprintw(LINES - 1, 0, "PID to kill: ");
+            getnstr(buf, sizeof(buf) - 1);
+            int pid = atoi(buf);
+            send_signal(pid, SIGTERM);
+            noecho();
+            curs_set(0);
+            nodelay(stdscr, TRUE);
+        } else if (ch == 'r') {
+            char buf1[16];
+            char buf2[16];
+            nodelay(stdscr, FALSE);
+            echo();
+            curs_set(1);
+            mvprintw(LINES - 1, 0, "PID to renice: ");
+            getnstr(buf1, sizeof(buf1) - 1);
+            mvprintw(LINES - 1, 0, "New nice value: ");
+            getnstr(buf2, sizeof(buf2) - 1);
+            int pid = atoi(buf1);
+            int nv = atoi(buf2);
+            change_priority(pid, nv);
+            noecho();
+            curs_set(0);
+            nodelay(stdscr, TRUE);
         }
     }
     endwin();

--- a/vtopdoc.md
+++ b/vtopdoc.md
@@ -64,3 +64,11 @@ The interactive display lists PID, USER, command name, state, virtual
 memory size, resident set size, memory usage percentage and CPU usage.
 In the interactive interface press `F3` or `>` to cycle to the next sort
 field and `<` to go back.
+
+Process management shortcuts are also available:
+
+- `k` &ndash; prompt for a PID and send `SIGTERM` to that process.
+- `r` &ndash; prompt for a PID and new nice value to adjust process priority.
+
+Use caution when running with elevated privileges because killing or
+renicing critical processes can destabilize the system.


### PR DESCRIPTION
## Summary
- add helper library for sending signals and changing nice levels
- wire up new `k` and `r` shortcuts in the UI
- document process control usage and precautions

## Testing
- `make WITH_UI=1`
- `./vtop -h`


------
https://chatgpt.com/codex/tasks/task_e_6854e2e331a483248020eda76afc2959