### PR TITLE
Add process filtering by user and command

### DIFF
--- a/include/proc.h
+++ b/include/proc.h
@@ -59,6 +59,12 @@ int read_mem_stats(struct mem_stats *stats);
 size_t list_processes(struct process_info *buf, size_t max);
 int read_misc_stats(struct misc_stats *stats);
 
+/* optional filtering */
+void set_name_filter(const char *substr);
+void set_user_filter(const char *user);
+const char *get_name_filter(void);
+const char *get_user_filter(void);
+
 /* comparison helpers for sorting */
 int cmp_proc_pid(const void *a, const void *b);
 int cmp_proc_cpu(const void *a, const void *b);


### PR DESCRIPTION
## Summary
- allow filtering the process list by command substring or username
- enable interactive filter input via `/` and `u` keys in the UI
- display active filters in the header line

## Testing
- `make WITH_UI=1`

------
https://chatgpt.com/codex/tasks/task_e_6854e60392cc83248b1911638a9fbb89