### PR TITLE
Add swap usage tracking

### DIFF
--- a/include/proc.h
+++ b/include/proc.h
@@ -20,6 +20,8 @@ struct mem_stats {
     unsigned long long available;
     unsigned long long buffers;
     unsigned long long cached;
+    unsigned long long swap_total;
+    unsigned long long swap_used;
 };
 
 struct misc_stats {

--- a/src/proc.c
+++ b/src/proc.c
@@ -126,6 +126,15 @@ int read_mem_stats(struct mem_stats *stats) {
         return -1;
     if (read_mem_value("Cached", &stats->cached) < 0)
         return -1;
+    if (read_mem_value("SwapTotal", &stats->swap_total) < 0)
+        return -1;
+    unsigned long long swap_free = 0;
+    if (read_mem_value("SwapFree", &swap_free) < 0)
+        return -1;
+    if (stats->swap_total >= swap_free)
+        stats->swap_used = stats->swap_total - swap_free;
+    else
+        stats->swap_used = 0;
     return 0;
 }
 

--- a/src/ui.c
+++ b/src/ui.c
@@ -68,6 +68,7 @@ int run_ui(unsigned int delay_ms, enum sort_field sort) {
     struct misc_stats misc;
     double cpu_usage = 0.0;
     double mem_usage = 0.0;
+    double swap_usage = 0.0;
 
     set_sort(sort);
     unsigned int interval = delay_ms;
@@ -91,6 +92,11 @@ int run_ui(unsigned int delay_ms, enum sort_field sort) {
         if (read_mem_stats(&ms) == 0 && ms.total > 0) {
             unsigned long long used = ms.total - ms.available;
             mem_usage = 100.0 * (double)used / (double)ms.total;
+            if (ms.swap_total > 0)
+                swap_usage = 100.0 * (double)ms.swap_used /
+                             (double)ms.swap_total;
+            else
+                swap_usage = 0.0;
         }
         read_misc_stats(&misc);
 
@@ -109,9 +115,10 @@ int run_ui(unsigned int delay_ms, enum sort_field sort) {
             strncat(fbuf, uf, sizeof(fbuf) - strlen(fbuf) - 1);
         }
         mvprintw(0, 0,
-                 "load %.2f %.2f %.2f  up %.0fs  tasks %d/%d  cpu %5.1f%%  mem %5.1f%%  intv %.1fs%s",
+                 "load %.2f %.2f %.2f  up %.0fs  tasks %d/%d  cpu %5.1f%%  mem %5.1f%%  swap %llu/%llu %.1f%%  intv %.1fs%s",
                  misc.load1, misc.load5, misc.load15, misc.uptime,
                  misc.running_tasks, misc.total_tasks, cpu_usage, mem_usage,
+                 ms.swap_used, ms.swap_total, swap_usage,
                  interval / 1000.0, fbuf);
         mvprintw(1, 0, "%s",
                  "PID      USER     NAME                     STATE  VSIZE    RSS  RSS%  CPU%   TIME     START");


### PR DESCRIPTION
## Summary
- extend `mem_stats` with swap information
- parse swap data from `/proc/meminfo`
- show swap use in the interface

## Testing
- `make clean >/tmp/make.log && make WITH_UI=1 >>/tmp/make.log`

------
https://chatgpt.com/codex/tasks/task_e_68556f4276008324a219a15cdec36456