### PR TITLE
Add sort order toggle feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The `-s` option selects the sort field. Available values are:
 
 When running the ncurses interface you can press `F3` or `>` to cycle to
 the next sort field and `<` to go back.
+Press `F4` or `o` to toggle between ascending and descending order.
 
 Additional shortcuts:
 
@@ -39,6 +40,7 @@ Additional shortcuts:
 - Use `+` and `-` to increase or decrease the refresh delay while running.
 - Press `c` to toggle per-core CPU usage display.
 - Press `a` to toggle between the short command name and the full command line.
+- Press `F4` or `o` to change the sort direction.
 - Press `space` to pause or resume updates.
 - Press `h` to open a small help window with available shortcuts.
 

--- a/include/proc.h
+++ b/include/proc.h
@@ -93,4 +93,8 @@ int cmp_proc_pid(const void *a, const void *b);
 int cmp_proc_cpu(const void *a, const void *b);
 int cmp_proc_mem(const void *a, const void *b);
 
+/* sort order control */
+void set_sort_descending(int desc);
+int get_sort_descending(void);
+
 #endif /* PROC_H */

--- a/src/proc.c
+++ b/src/proc.c
@@ -28,6 +28,11 @@ static size_t core_count;
 /* optional filters */
 static char name_filter[256] = "";
 static char user_filter[32] = "";
+/* sort order: 0 = ascending, 1 = descending */
+static int sort_descending;
+
+void set_sort_descending(int desc) { sort_descending = desc != 0; }
+int get_sort_descending(void) { return sort_descending; }
 
 void set_name_filter(const char *substr) {
     if (substr && *substr) {
@@ -425,25 +430,34 @@ int read_misc_stats(struct misc_stats *stats) {
 int cmp_proc_pid(const void *a, const void *b) {
     const struct process_info *pa = a;
     const struct process_info *pb = b;
-    return pa->pid - pb->pid;
+    int diff = pa->pid - pb->pid;
+    if (diff == 0)
+        return 0;
+    return sort_descending ? -diff : diff;
 }
 
 int cmp_proc_cpu(const void *a, const void *b) {
     const struct process_info *pa = a;
     const struct process_info *pb = b;
+    int res = 0;
     if (pa->cpu_usage < pb->cpu_usage)
-        return 1;
-    if (pa->cpu_usage > pb->cpu_usage)
-        return -1;
-    return 0;
+        res = -1;
+    else if (pa->cpu_usage > pb->cpu_usage)
+        res = 1;
+    if (sort_descending)
+        res = -res;
+    return res;
 }
 
 int cmp_proc_mem(const void *a, const void *b) {
     const struct process_info *pa = a;
     const struct process_info *pb = b;
+    int res = 0;
     if (pa->rss < pb->rss)
-        return 1;
-    if (pa->rss > pb->rss)
-        return -1;
-    return 0;
+        res = -1;
+    else if (pa->rss > pb->rss)
+        res = 1;
+    if (sort_descending)
+        res = -res;
+    return res;
 }

--- a/src/ui.c
+++ b/src/ui.c
@@ -26,22 +26,23 @@ static enum sort_field current_sort;
 static int (*compare_procs)(const void *, const void *) = cmp_proc_pid;
 
 static void show_help(void) {
-    const int h = 16;
+    const int h = 17;
     const int w = 52;
     WINDOW *win = newwin(h, w, (LINES - h) / 2, (COLS - w) / 2);
     box(win, 0, 0);
     mvwprintw(win, 1, 2, "Key bindings:");
     mvwprintw(win, 3, 2, "q  Quit");
     mvwprintw(win, 4, 2, "F3/>/<  Change sort field");
-    mvwprintw(win, 5, 2, "+/-     Adjust refresh delay");
-    mvwprintw(win, 6, 2, "/       Filter by command name");
-    mvwprintw(win, 7, 2, "u       Filter by user");
-    mvwprintw(win, 8, 2, "k       Kill a process");
-    mvwprintw(win, 9, 2, "r       Renice a process");
-    mvwprintw(win, 10, 2, "c       Toggle per-core view");
-    mvwprintw(win, 11, 2, "a       Toggle full command");
-    mvwprintw(win, 12, 2, "SPACE    Pause/resume");
-    mvwprintw(win, 13, 2, "h       Show this help");
+    mvwprintw(win, 5, 2, "F4/o    Toggle sort order");
+    mvwprintw(win, 6, 2, "+/-     Adjust refresh delay");
+    mvwprintw(win, 7, 2, "/       Filter by command name");
+    mvwprintw(win, 8, 2, "u       Filter by user");
+    mvwprintw(win, 9, 2, "k       Kill a process");
+    mvwprintw(win, 10, 2, "r       Renice a process");
+    mvwprintw(win, 11, 2, "c       Toggle per-core view");
+    mvwprintw(win, 12, 2, "a       Toggle full command");
+    mvwprintw(win, 13, 2, "SPACE    Pause/resume");
+    mvwprintw(win, 14, 2, "h       Show this help");
     mvwprintw(win, h - 2, 2, "Press any key to return");
     wrefresh(win);
     nodelay(stdscr, FALSE);
@@ -55,12 +56,15 @@ static void set_sort(enum sort_field sort) {
     switch (sort) {
     case SORT_PID:
         compare_procs = cmp_proc_pid;
+        set_sort_descending(0);
         break;
     case SORT_CPU:
         compare_procs = cmp_proc_cpu;
+        set_sort_descending(1);
         break;
     case SORT_MEM:
         compare_procs = cmp_proc_mem;
+        set_sort_descending(1);
         break;
     }
 }
@@ -261,6 +265,8 @@ int run_ui(unsigned int delay_ms, enum sort_field sort) {
             noecho();
             curs_set(0);
             nodelay(stdscr, TRUE);
+        } else if (ch == KEY_F(4) || ch == 'o') {
+            set_sort_descending(!get_sort_descending());
         } else if (ch == 'c') {
             show_cores = !show_cores;
         } else if (ch == 'a') {

--- a/vtopdoc.md
+++ b/vtopdoc.md
@@ -77,7 +77,7 @@ priority, nice value, virtual memory size, resident set size,
 memory usage percentage, CPU usage, total CPU time and the process
 start time.
 In the interactive interface press `F3` or `>` to cycle to the next sort
-field and `<` to go back.
+field and `<` to go back. Use `F4` or `o` to toggle the sort order.
 
 Process management shortcuts are also available:
 
@@ -85,6 +85,7 @@ Process management shortcuts are also available:
 - `r` &ndash; prompt for a PID and new nice value to adjust process priority.
 - `c` &ndash; toggle per-core CPU usage display.
 - `a` &ndash; toggle between the short name and full command line.
+- `F4`/`o` &ndash; change the sort direction.
 - `h` &ndash; display a help window showing available shortcuts.
 
 Use caution when running with elevated privileges because killing or


### PR DESCRIPTION
## Summary
- add functions to control sort order
- make process comparators honor the chosen order
- allow toggling sort direction with `F4` or `o`
- document the new shortcut

## Testing
- `make WITH_UI=1`

------
https://chatgpt.com/codex/tasks/task_e_6855827e03e883249267729381bb9f45