### PR TITLE
Add idle process filter toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Additional shortcuts:
 - Press `c` to toggle per-core CPU usage display.
 - Press `a` to toggle between the short command name and the full command line.
 - Press `H` to toggle thread view (show individual threads).
+- Press `i` to hide or show processes with zero CPU usage.
 - Press `F4` or `o` to change the sort direction.
 - Press `space` to pause or resume updates.
 - Press `h` to open a small help window with available shortcuts.

--- a/include/proc.h
+++ b/include/proc.h
@@ -105,4 +105,8 @@ int get_sort_descending(void);
 void set_thread_mode(int on);
 int get_thread_mode(void);
 
+/* show processes with zero CPU usage */
+void set_show_idle(int on);
+int get_show_idle(void);
+
 #endif /* PROC_H */

--- a/src/proc.c
+++ b/src/proc.c
@@ -36,12 +36,16 @@ static size_t pid_list_count;
 static int sort_descending;
 /* show threads instead of processes */
 static int thread_mode;
+static int show_idle = 1;
 
 void set_sort_descending(int desc) { sort_descending = desc != 0; }
 int get_sort_descending(void) { return sort_descending; }
 
 void set_thread_mode(int on) { thread_mode = on != 0; }
 int get_thread_mode(void) { return thread_mode; }
+
+void set_show_idle(int on) { show_idle = on != 0; }
+int get_show_idle(void) { return show_idle; }
 
 void set_name_filter(const char *substr) {
     if (substr && *substr) {
@@ -378,6 +382,10 @@ size_t list_processes(struct process_info *buf, size_t max) {
 
                     unsigned long long delta = (utime - old_utime) + (stime - old_stime);
                     double usage = 100.0 * (double)delta / (double)total_delta;
+                    if (!show_idle && delta == 0) {
+                        fclose(fp);
+                        continue;
+                    }
 
                     buf[count].pid = (int)pid;
                     buf[count].tid = (int)tid;
@@ -497,6 +505,10 @@ size_t list_processes(struct process_info *buf, size_t max) {
 
                 unsigned long long delta = (utime - old_utime) + (stime - old_stime);
                 double usage = 100.0 * (double)delta / (double)total_delta;
+                if (!show_idle && delta == 0) {
+                    fclose(fp);
+                    continue;
+                }
 
                 buf[count].pid = (int)pid;
                 buf[count].tid = (int)pid;

--- a/src/ui.c
+++ b/src/ui.c
@@ -22,12 +22,13 @@ static size_t core_count;
 static int show_cores;
 static int show_full_cmd;
 static int show_threads;
+static int show_idle = 1;
 
 static enum sort_field current_sort;
 static int (*compare_procs)(const void *, const void *) = cmp_proc_pid;
 
 static void show_help(void) {
-    const int h = 18;
+    const int h = 19;
     const int w = 52;
     WINDOW *win = newwin(h, w, (LINES - h) / 2, (COLS - w) / 2);
     box(win, 0, 0);
@@ -43,8 +44,9 @@ static void show_help(void) {
     mvwprintw(win, 11, 2, "c       Toggle per-core view");
     mvwprintw(win, 12, 2, "a       Toggle full command");
     mvwprintw(win, 13, 2, "H       Toggle thread view");
-    mvwprintw(win, 14, 2, "SPACE    Pause/resume");
-    mvwprintw(win, 15, 2, "h       Show this help");
+    mvwprintw(win, 14, 2, "i       Toggle idle processes");
+    mvwprintw(win, 15, 2, "SPACE    Pause/resume");
+    mvwprintw(win, 16, 2, "h       Show this help");
     mvwprintw(win, h - 2, 2, "Press any key to return");
     wrefresh(win);
     nodelay(stdscr, FALSE);
@@ -93,6 +95,7 @@ int run_ui(unsigned int delay_ms, enum sort_field sort,
     set_sort(sort);
     show_threads = get_thread_mode();
     set_thread_mode(show_threads);
+    set_show_idle(show_idle);
     unsigned int interval = delay_ms;
     if (interval < MIN_DELAY_MS)
         interval = MIN_DELAY_MS;
@@ -294,6 +297,9 @@ int run_ui(unsigned int delay_ms, enum sort_field sort,
         } else if (ch == 'H') {
             show_threads = !show_threads;
             set_thread_mode(show_threads);
+        } else if (ch == 'i') {
+            show_idle = !show_idle;
+            set_show_idle(show_idle);
         } else if (ch == ' ') {
             paused = !paused;
         } else if (ch == 'h') {


### PR DESCRIPTION
## Summary
- add `show_idle` flag in `ui.c` with `i` key binding
- expose `set_show_idle()` in `proc.c`
- skip idle processes when disabled
- document the new shortcut

## Testing
- `make WITH_UI=1`
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_6855a1f90110832493b1e2458f5f5783