### PR TITLE
Add color highlighting toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Additional shortcuts:
 - Press `a` to toggle between the short command name and the full command line.
 - Press `H` to toggle thread view (show individual threads).
 - Press `i` to hide or show processes with zero CPU usage.
+- Press `z` to toggle color output.
 - Press `F4` or `o` to change the sort direction.
 - Press `space` to pause or resume updates.
 - Press `h` to open a small help window with available shortcuts.


### PR DESCRIPTION
## Summary
- highlight sorted column and running tasks with ncurses colors
- allow toggling colors with the `z` key
- document the new shortcut

## Testing
- `make WITH_UI=1`
- `./vtop -b 1`

------
https://chatgpt.com/codex/tasks/task_e_6855a5c56d7083249860bebbea6a6fa4