### PR TITLE
Add configuration persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,19 @@ Additional shortcuts:
 - Press `F4` or `o` to change the sort direction.
 - Press `space` to pause or resume updates.
 - Press `h` to open a small help window with available shortcuts.
+- Press `W` to save the current configuration.
 
 These controls operate on live processes. Ensure you have permission to
 signal or renice the target process. Running as root can terminate or slow
 critical system tasks, so use with care.
+
+## Configuration
+
+When the ncurses interface exits it writes the current options to
+`~/.vtoprc`. This file stores the refresh interval, sort column and the
+enabled columns. On the next launch, vtop reads this file to restore the
+previous settings. You can also press `W` at any time to save the
+configuration manually.
 
 Example output with the ncurses interface:
 

--- a/include/ui.h
+++ b/include/ui.h
@@ -10,4 +10,13 @@ enum sort_field {
 int run_ui(unsigned int delay_ms, enum sort_field sort,
            unsigned int iterations);
 
+#ifdef WITH_UI
+/* Load configuration from ~/.vtoprc if available. The delay and sort
+ * parameters are updated with the loaded values. */
+int ui_load_config(unsigned int *delay_ms, enum sort_field *sort);
+
+/* Save the current configuration to ~/.vtoprc. */
+int ui_save_config(unsigned int delay_ms, enum sort_field sort);
+#endif
+
 #endif /* UI_H */

--- a/src/main.c
+++ b/src/main.c
@@ -79,6 +79,10 @@ int main(int argc, char *argv[]) {
     unsigned int delay_ms = 3000; /* default 3 seconds */
     enum sort_field sort = SORT_PID;
 
+#ifdef WITH_UI
+    ui_load_config(&delay_ms, &sort);
+#endif
+
     static struct option long_opts[] = {
         {"delay", required_argument, NULL, 'd'},
         {"sort", required_argument, NULL, 's'},


### PR DESCRIPTION
## Summary
- store UI settings in `~/.vtoprc`
- load this file on startup to set defaults
- add `W` key to save configuration manually
- document configuration feature

## Testing
- `make`
- `make WITH_UI=1`


------
https://chatgpt.com/codex/tasks/task_e_6855a705990483248a0396ac9f5f5b58