### PR TITLE
Add memory unit scaling options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC := gcc
 CFLAGS := -Wall -O2 -Iinclude
-SRC := src/main.c src/proc.c src/control.c
+SRC := src/main.c src/proc.c src/control.c src/units.c
 BIN := vtop
 
 ifdef WITH_UI

--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ The `-s` option selects the sort field. Available values are:
 The `-b`/`--batch` option runs without the ncurses interface and prints
 plain text updates. Use `-n N` to limit the number of refresh cycles;
 `0` runs indefinitely. The `-p` option restricts the output to the
-comma-separated list of PIDs given.
+comma-separated list of PIDs given. The `-E` and `-e` options control the
+units used when displaying memory. Both accept one of `k`, `m`, `g`, `t`,
+`p` or `e` for kilobytes through exabytes. `-E` affects the summary line
+while `-e` scales per-process values.
 
 When running the ncurses interface you can press `F3` or `>` to cycle to
 the next sort field and `<` to go back.

--- a/include/ui.h
+++ b/include/ui.h
@@ -10,6 +10,21 @@ enum sort_field {
 int run_ui(unsigned int delay_ms, enum sort_field sort,
            unsigned int iterations);
 
+enum mem_unit {
+    MEM_UNIT_K,
+    MEM_UNIT_M,
+    MEM_UNIT_G,
+    MEM_UNIT_T,
+    MEM_UNIT_P,
+    MEM_UNIT_E
+};
+
+extern enum mem_unit summary_unit;
+extern enum mem_unit proc_unit;
+
+double scale_kb(unsigned long long kb, enum mem_unit unit);
+const char *mem_unit_suffix(enum mem_unit unit);
+
 #ifdef WITH_UI
 /* Load configuration from ~/.vtoprc if available. The delay and sort
  * parameters are updated with the loaded values. */

--- a/src/main.c
+++ b/src/main.c
@@ -3,14 +3,32 @@
 #include <string.h>
 #include <unistd.h>
 #include <getopt.h>
+#include <ctype.h>
 #include "version.h"
 #include "ui.h"
 #include "proc.h"
 
+static enum mem_unit parse_unit(const char *arg) {
+    if (!arg || !*arg)
+        return MEM_UNIT_K;
+    char c = tolower((unsigned char)arg[0]);
+    switch (c) {
+    case 'm': return MEM_UNIT_M;
+    case 'g': return MEM_UNIT_G;
+    case 't': return MEM_UNIT_T;
+    case 'p': return MEM_UNIT_P;
+    case 'e': return MEM_UNIT_E;
+    case 'k':
+    default:  return MEM_UNIT_K;
+    }
+}
+
 static void usage(const char *prog) {
-    printf("Usage: %s [-d seconds] [-s column] [-b iter] [-n iter] [-p pid,...]\n", prog);
+    printf("Usage: %s [-d seconds] [-s column] [-E unit] [-e unit] [-b iter] [-n iter] [-p pid,...]\n", prog);
     printf("  -d, --delay SECS   Refresh delay in seconds (default 3)\n");
     printf("  -s, --sort  COL    Sort column: pid,cpu,mem (default pid)\n");
+    printf("  -E, --scale-summary-mem UNIT  Memory units for summary (k,m,g,t,p,e)\n");
+    printf("  -e, --scale-task-mem UNIT     Memory units for processes (k,m,g,t,p,e)\n");
     printf("  -b, --batch ITER   Batch mode iterations (0=loop forever)\n");
     printf("  -n, --iterations N Number of refresh cycles (0=run forever)\n");
     printf("  -p, --pid   LIST   Comma-separated PIDs to monitor\n");
@@ -54,18 +72,23 @@ static int run_batch(unsigned int delay_ms, enum sort_field sort,
         double swap_usage = 0.0;
         if (ms.swap_total > 0)
             swap_usage = 100.0 * (double)ms.swap_used / (double)ms.swap_total;
-        printf("load %.2f %.2f %.2f  up %.0fs  tasks %d/%d  cpu %5.1f%% us %.1f%% sy %.1f%% id %.1f%%  mem %5.1f%%  swap %llu/%llu %.1f%%  intv %.1fs\n",
+        double swap_used = scale_kb(ms.swap_used, summary_unit);
+        double swap_total = scale_kb(ms.swap_total, summary_unit);
+        printf("load %.2f %.2f %.2f  up %.0fs  tasks %d/%d  cpu %5.1f%% us %.1f%% sy %.1f%% id %.1f%%  mem %5.1f%%  swap %.0f/%.0f%s %.1f%%  intv %.1fs\n",
                misc.load1, misc.load5, misc.load15, misc.uptime,
                misc.running_tasks, misc.total_tasks,
                100.0 - cs.idle_percent, cs.user_percent, cs.system_percent,
-               cs.idle_percent, mem_usage, ms.swap_used, ms.swap_total,
-               swap_usage, delay_ms / 1000.0);
+               cs.idle_percent, mem_usage, swap_used, swap_total,
+               mem_unit_suffix(summary_unit), swap_usage, delay_ms / 1000.0);
         printf("PID      USER     NAME                     STATE PRI  NICE  VSIZE    RSS  RSS%%  CPU%%   TIME     START\n");
         for (size_t i = 0; i < count; i++) {
-            printf("%-8d %-8s %-25s %c %4ld %5ld %8llu %5ld %6.2f %6.2f %8.0f %-8s\n",
+            double vsz = procs[i].vsize / 1024.0; /* bytes to KB */
+            vsz = scale_kb((unsigned long long)vsz, proc_unit);
+            double rss = scale_kb((unsigned long long)procs[i].rss, proc_unit);
+            printf("%-8d %-8s %-25s %c %4ld %5ld %8.1f %5.1f %6.2f %6.2f %8.0f %-8s\n",
                    procs[i].pid, procs[i].user, procs[i].name, procs[i].state,
-                   procs[i].priority, procs[i].nice, procs[i].vsize,
-                   procs[i].rss, procs[i].rss_percent, procs[i].cpu_usage,
+                   procs[i].priority, procs[i].nice, vsz, rss,
+                   procs[i].rss_percent, procs[i].cpu_usage,
                    procs[i].cpu_time, procs[i].start_time);
         }
         fflush(stdout);
@@ -86,6 +109,8 @@ int main(int argc, char *argv[]) {
     static struct option long_opts[] = {
         {"delay", required_argument, NULL, 'd'},
         {"sort", required_argument, NULL, 's'},
+        {"scale-summary-mem", required_argument, NULL, 'E'},
+        {"scale-task-mem", required_argument, NULL, 'e'},
         {"batch", required_argument, NULL, 'b'},
         {"iterations", required_argument, NULL, 'n'},
         {"pid", required_argument, NULL, 'p'},
@@ -96,7 +121,7 @@ int main(int argc, char *argv[]) {
     int opt, idx;
     int batch = 0;
     unsigned int iterations = 0;
-    while ((opt = getopt_long(argc, argv, "d:s:b:n:p:h", long_opts, &idx)) != -1) {
+    while ((opt = getopt_long(argc, argv, "d:s:E:e:b:n:p:h", long_opts, &idx)) != -1) {
         switch (opt) {
         case 'd':
             delay_ms = (unsigned int)(strtod(optarg, NULL) * 1000);
@@ -108,6 +133,12 @@ int main(int argc, char *argv[]) {
                 sort = SORT_MEM;
             else
                 sort = SORT_PID;
+            break;
+        case 'E':
+            summary_unit = parse_unit(optarg);
+            break;
+        case 'e':
+            proc_unit = parse_unit(optarg);
             break;
         case 'b':
             batch = 1;

--- a/src/proc.c
+++ b/src/proc.c
@@ -432,8 +432,9 @@ size_t list_processes(struct process_info *buf, size_t max) {
                     buf[count].priority = priority;
                     buf[count].nice = niceval;
                     buf[count].vsize = vsize;
-                    buf[count].rss = rss;
-                    buf[count].rss_percent = 100.0 * (double)rss * (double)page_kb /
+                    long rss_kb = rss * page_kb;
+                    buf[count].rss = rss_kb;
+                    buf[count].rss_percent = 100.0 * (double)rss_kb /
                                            (double)ms.total;
                     buf[count].utime = utime;
                     buf[count].stime = stime;
@@ -555,8 +556,9 @@ size_t list_processes(struct process_info *buf, size_t max) {
                 buf[count].priority = priority;
                 buf[count].nice = niceval;
                 buf[count].vsize = vsize;
-                buf[count].rss = rss;
-                buf[count].rss_percent = 100.0 * (double)rss * (double)page_kb /
+                long rss_kb = rss * page_kb;
+                buf[count].rss = rss_kb;
+                buf[count].rss_percent = 100.0 * (double)rss_kb /
                                        (double)ms.total;
                 buf[count].utime = utime;
                 buf[count].stime = stime;

--- a/src/ui.c
+++ b/src/ui.c
@@ -244,14 +244,18 @@ static void draw_process_row(int row, const struct process_info *p) {
             mvprintw(row, x, columns[i].left ? "%-*ld" : "%*ld",
                      columns[i].width, p->nice);
             break;
-        case COL_VSIZE:
-            mvprintw(row, x, columns[i].left ? "%-*llu" : "%*llu",
-                     columns[i].width, p->vsize);
+        case COL_VSIZE: {
+            double vsz = scale_kb((p->vsize / 1024), proc_unit);
+            mvprintw(row, x, columns[i].left ? "%-*.1f" : "%*.1f",
+                     columns[i].width, vsz);
             break;
-        case COL_RSS:
-            mvprintw(row, x, columns[i].left ? "%-*ld" : "%*ld",
-                     columns[i].width, p->rss);
+        }
+        case COL_RSS: {
+            double rss = scale_kb((unsigned long long)p->rss, proc_unit);
+            mvprintw(row, x, columns[i].left ? "%-*.1f" : "%*.1f",
+                     columns[i].width, rss);
             break;
+        }
         case COL_RSSP:
             mvprintw(row, x, columns[i].left ? "%-*.2f" : "%*.2f",
                      columns[i].width, p->rss_percent);
@@ -460,12 +464,15 @@ int run_ui(unsigned int delay_ms, enum sort_field sort,
             strncat(fbuf, " user=", sizeof(fbuf) - strlen(fbuf) - 1);
             strncat(fbuf, uf, sizeof(fbuf) - strlen(fbuf) - 1);
         }
+        double swap_u = scale_kb(ms.swap_used, summary_unit);
+        double swap_t = scale_kb(ms.swap_total, summary_unit);
+        const char *unit = mem_unit_suffix(summary_unit);
         mvprintw(0, 0,
-                 "load %.2f %.2f %.2f  up %.0fs  tasks %d/%d  cpu %5.1f%% us %.1f%% sy %.1f%% id %.1f%%  mem %5.1f%%  swap %llu/%llu %.1f%%  intv %.1fs%s%s",
+                 "load %.2f %.2f %.2f  up %.0fs  tasks %d/%d  cpu %5.1f%% us %.1f%% sy %.1f%% id %.1f%%  mem %5.1f%%  swap %.0f/%.0f%s %.1f%%  intv %.1fs%s%s",
                  misc.load1, misc.load5, misc.load15, misc.uptime,
                  misc.running_tasks, misc.total_tasks, cpu_usage,
                  cs.user_percent, cs.system_percent, cs.idle_percent,
-                 mem_usage, ms.swap_used, ms.swap_total, swap_usage,
+                 mem_usage, swap_u, swap_t, unit, swap_usage,
                  interval / 1000.0, paused ? " [PAUSED]" : "", fbuf);
         int row = 1;
         if (show_cores && core_count > 0) {

--- a/src/units.c
+++ b/src/units.c
@@ -1,0 +1,36 @@
+#include "ui.h"
+#include <ctype.h>
+
+enum mem_unit summary_unit = MEM_UNIT_K;
+enum mem_unit proc_unit = MEM_UNIT_K;
+
+static double factor(enum mem_unit u) {
+    switch (u) {
+    case MEM_UNIT_M: return 1024.0;
+    case MEM_UNIT_G: return 1024.0 * 1024.0;
+    case MEM_UNIT_T: return 1024.0 * 1024.0 * 1024.0;
+    case MEM_UNIT_P: return 1024.0 * 1024.0 * 1024.0 * 1024.0;
+    case MEM_UNIT_E: return 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0;
+    case MEM_UNIT_K:
+    default:
+        return 1.0;
+    }
+}
+
+double scale_kb(unsigned long long kb, enum mem_unit unit) {
+    return (double)kb / factor(unit);
+}
+
+const char *mem_unit_suffix(enum mem_unit u) {
+    switch (u) {
+    case MEM_UNIT_M: return "M";
+    case MEM_UNIT_G: return "G";
+    case MEM_UNIT_T: return "T";
+    case MEM_UNIT_P: return "P";
+    case MEM_UNIT_E: return "E";
+    case MEM_UNIT_K:
+    default:
+        return "K";
+    }
+}
+

--- a/vtopdoc.md
+++ b/vtopdoc.md
@@ -59,6 +59,9 @@ monitoring tools without requiring additional dependencies.
 
 `vtop` accepts a few options similar to classic `top`.
 
+- `-E UNIT` &mdash; Set memory units for the summary line.
+- `-e UNIT` &mdash; Set memory units for per-process values.
+
 - `-d SECS` &mdash; Set the refresh delay in seconds. The default is
   `3` seconds just like `top`.
 - `-s COL` &mdash; Choose the column to sort by. Supported values are


### PR DESCRIPTION
## Summary
- support selecting memory display units (k/m/g/etc.)
- implement `-E` and `-e` command line options
- scale memory values in UI and batch output
- document new options

## Testing
- `make WITH_UI=1`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6855ac548eb48324b65382d6e028399b