### PR TITLE
Add width override option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ comma-separated list of PIDs given. The `-E` and `-e` options control the
 units used when displaying memory. Both accept one of `k`, `m`, `g`, `t`,
 `p` or `e` for kilobytes through exabytes. `-E` affects the summary line
 while `-e` scales per-process values.
+The `-w` option allows overriding the screen width used by the ncurses
+layout. When the specified width is smaller than the default, columns are
+truncated to fit.
 
 When running the ncurses interface you can press `F3` or `>` to cycle to
 the next sort field and `<` to go back.

--- a/include/ui.h
+++ b/include/ui.h
@@ -8,7 +8,7 @@ enum sort_field {
 };
 
 int run_ui(unsigned int delay_ms, enum sort_field sort,
-           unsigned int iterations);
+           unsigned int iterations, int columns);
 
 enum mem_unit {
     MEM_UNIT_K,

--- a/src/ui.c
+++ b/src/ui.c
@@ -288,7 +288,13 @@ static void field_manager(void) {
     int sel = 0;
     int h = n + 4;
     int w = 20;
-    WINDOW *win = newwin(h, w, (LINES - h) / 2, (COLS - w) / 2);
+    int startx = COLS > w ? (COLS - w) / 2 : 0;
+    if (startx < 0)
+        startx = 0;
+    int starty = LINES > h ? (LINES - h) / 2 : 0;
+    if (starty < 0)
+        starty = 0;
+    WINDOW *win = newwin(h, w, starty, startx);
     keypad(win, TRUE);
     nodelay(stdscr, FALSE);
     int ch = 0;
@@ -316,7 +322,13 @@ static void field_manager(void) {
 static void show_help(void) {
     const int h = 22;
     const int w = 52;
-    WINDOW *win = newwin(h, w, (LINES - h) / 2, (COLS - w) / 2);
+    int startx = COLS > w ? (COLS - w) / 2 : 0;
+    if (startx < 0)
+        startx = 0;
+    int starty = LINES > h ? (LINES - h) / 2 : 0;
+    if (starty < 0)
+        starty = 0;
+    WINDOW *win = newwin(h, w, starty, startx);
     box(win, 0, 0);
     mvwprintw(win, 1, 2, "Key bindings:");
     mvwprintw(win, 3, 2, "q  Quit");
@@ -363,8 +375,10 @@ static void set_sort(enum sort_field sort) {
 }
 
 int run_ui(unsigned int delay_ms, enum sort_field sort,
-           unsigned int iterations) {
+           unsigned int iterations, int columns) {
     initscr();
+    if (columns > 0)
+        resizeterm(LINES, columns);
     cbreak();
     noecho();
     keypad(stdscr, TRUE);


### PR DESCRIPTION
## Summary
- add `-w` option to specify column width
- resize ncurses screen when a custom width is provided
- center pop-up windows safely when the screen is small
- document the new feature

## Testing
- `make clean && make WITH_UI=1`
- `./vtop -w 40 -b 1` (ran briefly)


------
https://chatgpt.com/codex/tasks/task_e_6855ae9211e483248a8e715232e21c56