### PR TITLE
Dynamic process list allocation

### DIFF
--- a/include/proc.h
+++ b/include/proc.h
@@ -81,6 +81,7 @@ int read_cpu_stats(struct cpu_stats *stats);
 size_t get_cpu_core_count(void);
 const struct cpu_core_stats *get_cpu_core_stats(void);
 int read_mem_stats(struct mem_stats *stats);
+size_t count_processes(void);
 size_t list_processes(struct process_info *buf, size_t max);
 int read_misc_stats(struct misc_stats *stats);
 


### PR DESCRIPTION
## Summary
- add `count_processes()` helper and header declaration
- allocate process list dynamically in UI and batch modes
- free new allocations on exit

## Testing
- `make WITH_UI=1`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6855afbeabcc83248c1de5469542b2bc