### PR TITLE
Add process entry limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ comma-separated list of PIDs given. The `-E` and `-e` options control the
 units used when displaying memory. Both accept one of `k`, `m`, `g`, `t`,
 `p` or `e` for kilobytes through exabytes. `-E` affects the summary line
 while `-e` scales per-process values.
+Use `-m N` to limit the number of displayed tasks.
 The `-w` option allows overriding the screen width used by the ncurses
 layout. When the specified width is smaller than the default, columns are
 truncated to fit.

--- a/include/ui.h
+++ b/include/ui.h
@@ -1,6 +1,8 @@
 #ifndef UI_H
 #define UI_H
 
+#include <stddef.h>
+
 enum sort_field {
     SORT_PID,
     SORT_CPU,
@@ -10,7 +12,7 @@ enum sort_field {
 };
 
 int run_ui(unsigned int delay_ms, enum sort_field sort,
-           unsigned int iterations, int columns);
+           unsigned int iterations, int columns, size_t max_entries);
 
 enum mem_unit {
     MEM_UNIT_K,


### PR DESCRIPTION
## Summary
- allow setting a maximum number of entries via `-m`
- honour entry limit in batch and UI modes
- allow changing the limit interactively with the `n` key
- document new option and update help dialog

## Testing
- `make WITH_UI=1`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6855c703f9a48324a95928315b282d2a