### PR TITLE
Add secure mode to disable task control

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Use `-m N` to limit the number of displayed tasks.
 The `-w` option allows overriding the screen width used by the ncurses
 layout. When the specified width is smaller than the default, columns are
 truncated to fit.
+The `-S`/`--secure` flag disables sending signals and changing
+process priorities. Use this when running vtop in restricted
+environments.
 
 When running the ncurses interface you can press `F3` or `>` to cycle to
 the next sort field and `<` to go back.

--- a/include/control.h
+++ b/include/control.h
@@ -1,6 +1,8 @@
 #ifndef CONTROL_H
 #define CONTROL_H
 
+extern int secure_mode;
+
 int send_signal(int pid, int sig);
 int change_priority(int pid, int niceval);
 

--- a/src/control.c
+++ b/src/control.c
@@ -1,11 +1,22 @@
 #include "control.h"
 #include <signal.h>
 #include <sys/resource.h>
+#include <errno.h>
+
+int secure_mode;
 
 int send_signal(int pid, int sig) {
+    if (secure_mode) {
+        errno = EPERM;
+        return -1;
+    }
     return kill(pid, sig);
 }
 
 int change_priority(int pid, int niceval) {
+    if (secure_mode) {
+        errno = EPERM;
+        return -1;
+    }
     return setpriority(PRIO_PROCESS, pid, niceval);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,7 @@
 #include "version.h"
 #include "ui.h"
 #include "proc.h"
+#include "control.h"
 
 /* maximum number of process entries to display (0 = unlimited) */
 static size_t max_entries;
@@ -27,8 +28,9 @@ static enum mem_unit parse_unit(const char *arg) {
 }
 
 static void usage(const char *prog) {
-    printf("Usage: %s [-d seconds] [-s column] [-E unit] [-e unit] [-b iter] [-n iter] [-m max] [-p pid,...] [-w cols]\n", prog);
+    printf("Usage: %s [-d seconds] [-S] [-s column] [-E unit] [-e unit] [-b iter] [-n iter] [-m max] [-p pid,...] [-w cols]\n", prog);
     printf("  -d, --delay SECS   Refresh delay in seconds (default 3)\n");
+    printf("  -S, --secure       Disable signaling and renicing tasks\n");
     printf("  -s, --sort  COL    Sort column: pid,cpu,mem,time,pri (default pid)\n");
     printf("  -E, --scale-summary-mem UNIT  Memory units for summary (k,m,g,t,p,e)\n");
     printf("  -e, --scale-task-mem UNIT     Memory units for processes (k,m,g,t,p,e)\n");
@@ -134,6 +136,7 @@ int main(int argc, char *argv[]) {
 
     static struct option long_opts[] = {
         {"delay", required_argument, NULL, 'd'},
+        {"secure", no_argument, NULL, 'S'},
         {"sort", required_argument, NULL, 's'},
         {"scale-summary-mem", required_argument, NULL, 'E'},
         {"scale-task-mem", required_argument, NULL, 'e'},
@@ -150,10 +153,13 @@ int main(int argc, char *argv[]) {
     int batch = 0;
     unsigned int iterations = 0;
     int columns = 0;
-    while ((opt = getopt_long(argc, argv, "d:s:E:e:b:n:m:p:w:h", long_opts, &idx)) != -1) {
+    while ((opt = getopt_long(argc, argv, "d:Ss:E:e:b:n:m:p:w:h", long_opts, &idx)) != -1) {
         switch (opt) {
         case 'd':
             delay_ms = (unsigned int)(strtod(optarg, NULL) * 1000);
+            break;
+        case 'S':
+            secure_mode = 1;
             break;
         case 's':
             if (strcmp(optarg, "cpu") == 0)

--- a/vtopdoc.md
+++ b/vtopdoc.md
@@ -66,6 +66,8 @@ monitoring tools without requiring additional dependencies.
   `3` seconds just like `top`.
 - `-s COL` &mdash; Choose the column to sort by. Supported values are
   `pid`, `cpu` and `mem`. The default is `pid`.
+- `-S` &mdash; Enable secure mode which disables signaling and renicing
+  processes.
 
 Examples:
 
@@ -73,6 +75,7 @@ Examples:
 vtop              # run with defaults (3s delay, sort by pid)
 vtop -d 1         # update every second
 vtop -s cpu       # sort processes by CPU usage
+vtop -S           # run without ability to signal or renice
 ```
 
 The interactive display lists PID, USER, command name, state,


### PR DESCRIPTION
## Summary
- add global `secure_mode` flag
- parse `-S/--secure` option to enable secure mode
- prevent signals and priority changes when secure
- document secure mode in README and vtopdoc

## Testing
- `make clean`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68561f10f8c483248f30d180e2791bde