### PR TITLE
Add column reordering with h/l

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Additional shortcuts:
 - Press `space` to pause or resume updates.
 - Press `h` to open a small help window with available shortcuts.
 - Press `W` to save the current configuration.
+- Press `f` to open the field manager. Use `space` to toggle visibility and
+  `h`/`l` to move the selected column left or right.
 
 These controls operate on live processes. Ensure you have permission to
 signal or renice the target process. Running as root can terminate or slow
@@ -77,9 +79,9 @@ critical system tasks, so use with care.
 ## Configuration
 
 When the ncurses interface exits it writes the current options to
-`~/.vtoprc`. This file stores the refresh interval, sort column and the
-enabled columns as well as the chosen memory units. On the next launch,
-vtop reads this file to restore the
+`~/.vtoprc`. This file stores the refresh interval, sort column, the
+enabled columns and their order as well as the chosen memory units. On the
+next launch, vtop reads this file to restore the
 previous settings. You can also press `W` at any time to save the
 configuration manually.
 

--- a/src/ui.c
+++ b/src/ui.c
@@ -406,7 +406,7 @@ static void field_manager(void) {
     build_ordered_indices(order);
     int sel = 0;
     int h = n + 4;
-    int w = 20;
+    int w = 32;
     int startx = COLS > w ? (COLS - w) / 2 : 0;
     if (startx < 0)
         startx = 0;
@@ -419,7 +419,7 @@ static void field_manager(void) {
     int ch = 0;
     while (ch != '\n' && ch != 'q' && ch != 27) {
         box(win, 0, 0);
-        mvwprintw(win, 1, 2, "Toggle fields (u/d move):");
+        mvwprintw(win, 1, 2, "Toggle fields (u/d or h/l move):");
         for (int i = 0; i < n; i++) {
             int idx = order[i];
             mvwprintw(win, i + 2, 2, "[%c] %s", columns[idx].enabled ? 'x' : ' ',
@@ -434,7 +434,7 @@ static void field_manager(void) {
             sel++;
         else if (ch == ' ')
             columns[order[sel]].enabled = !columns[order[sel]].enabled;
-        else if ((ch == 'u' || ch == 'U') && sel > 0) {
+        else if ((ch == 'u' || ch == 'U' || ch == 'h' || ch == 'H' || ch == KEY_LEFT) && sel > 0) {
             int idx = order[sel];
             int prev = order[sel - 1];
             int tmp = columns[idx].order;
@@ -443,7 +443,7 @@ static void field_manager(void) {
             order[sel] = prev;
             order[sel - 1] = idx;
             sel--;
-        } else if ((ch == 'd' || ch == 'D') && sel < n - 1) {
+        } else if ((ch == 'd' || ch == 'D' || ch == 'l' || ch == 'L' || ch == KEY_RIGHT) && sel < n - 1) {
             int idx = order[sel];
             int next = order[sel + 1];
             int tmp = columns[idx].order;

--- a/vtopdoc.md
+++ b/vtopdoc.md
@@ -98,6 +98,8 @@ Process management shortcuts are also available:
 - `U` &ndash; sort by user.
 - `B` &ndash; sort by start time.
 - `h` &ndash; display a help window showing available shortcuts.
+- `f` &ndash; open the field manager to hide columns or reorder them
+  with `h`/`l`.
 
 Use caution when running with elevated privileges because killing or
 renicing critical processes can destabilize the system.


### PR DESCRIPTION
## Summary
- allow moving columns left/right via `h` and `l`
- persist column order through configuration
- document column manager usage and config

## Testing
- `make clean`
- `make WITH_UI=1`

------
https://chatgpt.com/codex/tasks/task_e_68562535ed00832493cbbbab16850a62