### PR TITLE
Add cmdline and hide-idle options

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ The `-S`/`--secure` flag disables sending signals and changing
 process priorities. Use this when running vtop in restricted
 environments.
 The `--accum` option displays CPU time including dead children.
+The `-a`/`--cmdline` flag shows the full command line instead of the short
+command name.
+Use `-i`/`--hide-idle` to start with idle processes hidden.
 
 When running the ncurses interface you can press `F3` or `>` to cycle to
 the next sort field and `<` to go back.

--- a/include/ui.h
+++ b/include/ui.h
@@ -33,6 +33,8 @@ const char *mem_unit_suffix(enum mem_unit unit);
 enum mem_unit next_mem_unit(enum mem_unit unit);
 
 #ifdef WITH_UI
+void ui_set_show_full_cmd(int on);
+void ui_set_show_idle(int on);
 /* Load configuration from ~/.vtoprc if available. The delay and sort
  * parameters are updated with the loaded values. */
 int ui_load_config(unsigned int *delay_ms, enum sort_field *sort);

--- a/src/main.c
+++ b/src/main.c
@@ -28,7 +28,7 @@ static enum mem_unit parse_unit(const char *arg) {
 }
 
 static void usage(const char *prog) {
-    printf("Usage: %s [-d seconds] [-S] [--accum] [-s column] [-E unit] [-e unit] [-b iter] [-n iter] [-m max] [-p pid,...] [-w cols]\n", prog);
+    printf("Usage: %s [-d seconds] [-S] [-a] [-i] [--accum] [-s column] [-E unit] [-e unit] [-b iter] [-n iter] [-m max] [-p pid,...] [-w cols]\n", prog);
     printf("  -d, --delay SECS   Refresh delay in seconds (default 3)\n");
     printf("  -S, --secure       Disable signaling and renicing tasks\n");
     printf("  -s, --sort  COL    Sort column: pid,cpu,mem,user,start,time,pri (default pid)\n");
@@ -39,6 +39,8 @@ static void usage(const char *prog) {
     printf("  -p, --pid   LIST   Comma-separated PIDs to monitor\n");
     printf("  -m, --max   N     Maximum number of processes to display (0=all)\n");
     printf("  -w, --width COLS  Override screen width in columns\n");
+    printf("  -a, --cmdline     Display the full command line by default\n");
+    printf("  -i, --hide-idle   Hide processes with zero CPU usage\n");
     printf("      --accum       Include child CPU time in TIME column\n");
 }
 
@@ -155,6 +157,8 @@ int main(int argc, char *argv[]) {
         {"max", required_argument, NULL, 'm'},
         {"pid", required_argument, NULL, 'p'},
         {"width", required_argument, NULL, 'w'},
+        {"cmdline", no_argument, NULL, 'a'},
+        {"hide-idle", no_argument, NULL, 'i'},
         {"accum", no_argument, NULL, 1},
         {"help", no_argument, NULL, 'h'},
         {NULL, 0, NULL, 0}
@@ -164,7 +168,7 @@ int main(int argc, char *argv[]) {
     int batch = 0;
     unsigned int iterations = 0;
     int columns = 0;
-    while ((opt = getopt_long(argc, argv, "d:Ss:E:e:b:n:m:p:w:h", long_opts, &idx)) != -1) {
+    while ((opt = getopt_long(argc, argv, "d:Ss:E:e:b:n:m:p:w:aih", long_opts, &idx)) != -1) {
         switch (opt) {
         case 'd':
             delay_ms = (unsigned int)(strtod(optarg, NULL) * 1000);
@@ -215,6 +219,16 @@ int main(int argc, char *argv[]) {
             columns = atoi(optarg);
             if (columns < 0)
                 columns = 0;
+            break;
+        case 'a':
+#ifdef WITH_UI
+            ui_set_show_full_cmd(1);
+#endif
+            break;
+        case 'i':
+#ifdef WITH_UI
+            ui_set_show_idle(0);
+#endif
             break;
         case 'h':
         default:

--- a/src/ui.c
+++ b/src/ui.c
@@ -104,6 +104,10 @@ static enum mem_unit parse_mem_unit(const char *arg) {
     }
 }
 
+void ui_set_show_full_cmd(int on) { show_full_cmd = on != 0; }
+
+void ui_set_show_idle(int on) { show_idle = on != 0; }
+
 int ui_load_config(unsigned int *delay_ms, enum sort_field *sort) {
     const char *path = get_config_path();
     FILE *fp = fopen(path, "r");

--- a/vtopdoc.md
+++ b/vtopdoc.md
@@ -70,6 +70,9 @@ monitoring tools without requiring additional dependencies.
 - `-S` &mdash; Enable secure mode which disables signaling and renicing
   processes.
 - `--accum` &mdash; Include child CPU time when displaying `TIME`.
+- `-a`/`--cmdline` &mdash; Show the full command line instead of just the
+  process name.
+- `-i`/`--hide-idle` &mdash; Do not list tasks with zero CPU usage.
 
 Examples:
 
@@ -79,6 +82,8 @@ vtop -d 1         # update every second
 vtop -s cpu       # sort processes by CPU usage
 vtop -S           # run without ability to signal or renice
 vtop --accum      # include child CPU time in display
+vtop -a           # show full command line at startup
+vtop -i           # hide idle processes on launch
 ```
 
 The interactive display lists PID, USER, command name, state,


### PR DESCRIPTION
## Summary
- add `--cmdline` and `--hide-idle` CLI options with short forms
- allow toggling full command and idle processes at startup
- document the new command line flags

## Testing
- `make WITH_UI=1`

------
https://chatgpt.com/codex/tasks/task_e_68562723934c83248bb4b49bbe488324