### PR TITLE
Add --list-fields option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The `-S`/`--secure` flag disables sending signals and changing
 process priorities. Use this when running vtop in restricted
 environments.
 The `--accum` option displays CPU time including dead children.
+The `--list-fields` option prints all available column names and exits.
 The `-a`/`--cmdline` flag shows the full command line instead of the short
 command name.
 Use `-i`/`--hide-idle` to start with idle processes hidden.

--- a/include/ui.h
+++ b/include/ui.h
@@ -41,6 +41,9 @@ int ui_load_config(unsigned int *delay_ms, enum sort_field *sort);
 
 /* Save the current configuration to ~/.vtoprc. */
 int ui_save_config(unsigned int delay_ms, enum sort_field sort);
+
+/* Print the available column titles, one per line. */
+void ui_list_fields(void);
 #endif
 
 #endif /* UI_H */

--- a/src/main.c
+++ b/src/main.c
@@ -42,6 +42,9 @@ static void usage(const char *prog) {
     printf("  -a, --cmdline     Display the full command line by default\n");
     printf("  -i, --hide-idle   Hide processes with zero CPU usage\n");
     printf("      --accum       Include child CPU time in TIME column\n");
+#ifdef WITH_UI
+    printf("      --list-fields  Print column names and exit\n");
+#endif
 }
 
 static int run_batch(unsigned int delay_ms, enum sort_field sort,
@@ -159,6 +162,9 @@ int main(int argc, char *argv[]) {
         {"width", required_argument, NULL, 'w'},
         {"cmdline", no_argument, NULL, 'a'},
         {"hide-idle", no_argument, NULL, 'i'},
+#ifdef WITH_UI
+        {"list-fields", no_argument, NULL, 2},
+#endif
         {"accum", no_argument, NULL, 1},
         {"help", no_argument, NULL, 'h'},
         {NULL, 0, NULL, 0}
@@ -179,6 +185,11 @@ int main(int argc, char *argv[]) {
         case 1:
             set_show_accum_time(1);
             break;
+        case 2:
+#ifdef WITH_UI
+            ui_list_fields();
+#endif
+            return 0;
         case 's':
             if (strcmp(optarg, "cpu") == 0)
                 sort = SORT_CPU;

--- a/src/ui.c
+++ b/src/ui.c
@@ -79,6 +79,11 @@ static struct column_def columns[COL_COUNT] = {
     {COL_START, "START",   8, 1, 1,12}
 };
 
+void ui_list_fields(void) {
+    for (int i = 0; i < COL_COUNT; i++)
+        printf("%s\n", columns[i].title);
+}
+
 /* configuration file helpers */
 static const char *get_config_path(void) {
     const char *home = getenv("HOME");

--- a/vtopdoc.md
+++ b/vtopdoc.md
@@ -70,6 +70,7 @@ monitoring tools without requiring additional dependencies.
 - `-S` &mdash; Enable secure mode which disables signaling and renicing
   processes.
 - `--accum` &mdash; Include child CPU time when displaying `TIME`.
+- `--list-fields` &mdash; Print the names of all available columns and exit.
 - `-a`/`--cmdline` &mdash; Show the full command line instead of just the
   process name.
 - `-i`/`--hide-idle` &mdash; Do not list tasks with zero CPU usage.


### PR DESCRIPTION
## Summary
- expose column titles through `ui_list_fields`
- add `--list-fields` CLI option and usage text
- document the option in README and vtopdoc

## Testing
- `make WITH_UI=1`
- `./vtop --list-fields`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68562848dc9883249c558e004b585600