### PR TITLE
Add Irix mode toggle for CPU percentages

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The `--list-fields` option prints all available column names and exits.
 The `-a`/`--cmdline` flag shows the full command line instead of the short
 command name.
 Use `-i`/`--hide-idle` to start with idle processes hidden.
+Use `--irix` to display CPU usage relative to a single CPU.
 
 When running the ncurses interface you can press `F3` or `>` to cycle to
 the next sort field and `<` to go back.
@@ -66,6 +67,7 @@ Additional shortcuts:
 - Press `i` to hide or show processes with zero CPU usage.
 - Press `z` to toggle color output.
 - Press `S` to toggle cumulative CPU time.
+- Press `I` to toggle Irix mode (no CPU scaling).
 - Press `E` to cycle through memory units used for display.
 - Press `F4` or `o` to change the sort direction.
 - Press `U` to sort by user.

--- a/include/proc.h
+++ b/include/proc.h
@@ -132,4 +132,8 @@ int get_show_idle(void);
 void set_show_accum_time(int on);
 int get_show_accum_time(void);
 
+/* irix mode: do not scale CPU% by number of CPUs */
+void set_cpu_irix_mode(int on);
+int get_cpu_irix_mode(void);
+
 #endif /* PROC_H */

--- a/src/main.c
+++ b/src/main.c
@@ -41,6 +41,7 @@ static void usage(const char *prog) {
     printf("  -w, --width COLS  Override screen width in columns\n");
     printf("  -a, --cmdline     Display the full command line by default\n");
     printf("  -i, --hide-idle   Hide processes with zero CPU usage\n");
+    printf("      --irix        Do not scale CPU%% by number of CPUs\n");
     printf("      --accum       Include child CPU time in TIME column\n");
 #ifdef WITH_UI
     printf("      --list-fields  Print column names and exit\n");
@@ -166,6 +167,7 @@ int main(int argc, char *argv[]) {
         {"list-fields", no_argument, NULL, 2},
 #endif
         {"accum", no_argument, NULL, 1},
+        {"irix", no_argument, NULL, 3},
         {"help", no_argument, NULL, 'h'},
         {NULL, 0, NULL, 0}
     };
@@ -190,6 +192,9 @@ int main(int argc, char *argv[]) {
             ui_list_fields();
 #endif
             return 0;
+        case 3:
+            set_cpu_irix_mode(1);
+            break;
         case 's':
             if (strcmp(optarg, "cpu") == 0)
                 sort = SORT_CPU;

--- a/src/proc.c
+++ b/src/proc.c
@@ -38,6 +38,7 @@ static int sort_descending;
 static int thread_mode;
 static int show_idle = 1;
 static int show_accum_time;
+static int cpu_irix_mode;
 
 void set_sort_descending(int desc) { sort_descending = desc != 0; }
 int get_sort_descending(void) { return sort_descending; }
@@ -50,6 +51,9 @@ int get_show_idle(void) { return show_idle; }
 
 void set_show_accum_time(int on) { show_accum_time = on != 0; }
 int get_show_accum_time(void) { return show_accum_time; }
+
+void set_cpu_irix_mode(int on) { cpu_irix_mode = on != 0; }
+int get_cpu_irix_mode(void) { return cpu_irix_mode; }
 
 void set_name_filter(const char *substr) {
     if (substr && *substr) {
@@ -432,6 +436,11 @@ size_t list_processes(struct process_info *buf, size_t max) {
 
                     unsigned long long delta = (utime - old_utime) + (stime - old_stime);
                     double usage = 100.0 * (double)delta / (double)total_delta;
+                    if (get_cpu_irix_mode()) {
+                        size_t ncpu = get_cpu_core_count();
+                        if (ncpu > 0)
+                            usage *= (double)ncpu;
+                    }
                     if (!show_idle && delta == 0) {
                         fclose(fp);
                         continue;
@@ -564,6 +573,11 @@ size_t list_processes(struct process_info *buf, size_t max) {
 
                 unsigned long long delta = (utime - old_utime) + (stime - old_stime);
                 double usage = 100.0 * (double)delta / (double)total_delta;
+                if (get_cpu_irix_mode()) {
+                    size_t ncpu = get_cpu_core_count();
+                    if (ncpu > 0)
+                        usage *= (double)ncpu;
+                }
                 if (!show_idle && delta == 0) {
                     fclose(fp);
                     continue;

--- a/src/ui.c
+++ b/src/ui.c
@@ -468,7 +468,7 @@ static void field_manager(void) {
 }
 
 static void show_help(void) {
-    const int h = 31;
+    const int h = 32;
     const int w = 52;
     int startx = COLS > w ? (COLS - w) / 2 : 0;
     if (startx < 0)
@@ -499,14 +499,15 @@ static void show_help(void) {
     mvwprintw(win, 20, 2, "V       Toggle process tree");
     mvwprintw(win, 21, 2, "z       Toggle colors");
     mvwprintw(win, 22, 2, "S       Toggle cumulative time");
-    mvwprintw(win, 23, 2, "E       Cycle memory units");
-    mvwprintw(win, 24, 2, "t       Toggle CPU summary");
-    mvwprintw(win, 25, 2, "m       Toggle memory summary");
-    mvwprintw(win, 26, 2, "f       Field manager");
-    mvwprintw(win, 27, 2, "n       Set entry limit");
-    mvwprintw(win, 28, 2, "W       Save config");
-    mvwprintw(win, 29, 2, "SPACE    Pause/resume");
-    mvwprintw(win, 30, 2, "h       Show this help");
+    mvwprintw(win, 23, 2, "I       Toggle Irix mode");
+    mvwprintw(win, 24, 2, "E       Cycle memory units");
+    mvwprintw(win, 25, 2, "t       Toggle CPU summary");
+    mvwprintw(win, 26, 2, "m       Toggle memory summary");
+    mvwprintw(win, 27, 2, "f       Field manager");
+    mvwprintw(win, 28, 2, "n       Set entry limit");
+    mvwprintw(win, 29, 2, "W       Save config");
+    mvwprintw(win, 30, 2, "SPACE    Pause/resume");
+    mvwprintw(win, 31, 2, "h       Show this help");
     mvwprintw(win, h - 2, 2, "Press any key to return");
     wrefresh(win);
     nodelay(stdscr, FALSE);
@@ -885,6 +886,8 @@ int run_ui(unsigned int delay_ms, enum sort_field sort,
                 attrset(A_NORMAL);
         } else if (ch == 'S') {
             set_show_accum_time(!get_show_accum_time());
+        } else if (ch == 'I') {
+            set_cpu_irix_mode(!get_cpu_irix_mode());
         } else if (ch == 'E') {
             summary_unit = next_mem_unit(summary_unit);
             proc_unit = next_mem_unit(proc_unit);

--- a/vtopdoc.md
+++ b/vtopdoc.md
@@ -74,6 +74,7 @@ monitoring tools without requiring additional dependencies.
 - `-a`/`--cmdline` &mdash; Show the full command line instead of just the
   process name.
 - `-i`/`--hide-idle` &mdash; Do not list tasks with zero CPU usage.
+- `--irix` &mdash; Display per-process CPU usage relative to one CPU.
 
 Examples:
 
@@ -101,6 +102,7 @@ Process management shortcuts are also available:
 - `c` &ndash; toggle per-core CPU usage display.
 - `a` &ndash; toggle between the short name and full command line.
 - `S` &ndash; toggle cumulative CPU time display.
+- `I` &ndash; toggle Irix mode (CPU usage of each task not divided by CPU count).
 - `F4`/`o` &ndash; change the sort direction.
 - `U` &ndash; sort by user.
 - `B` &ndash; sort by start time.


### PR DESCRIPTION
## Summary
- implement `cpu_irix_mode` flag to control CPU percentage scaling
- provide `--irix` command-line option
- add interactive `I` key and help entry
- update process CPU usage calculations
- document Irix mode and shortcuts

## Testing
- `make WITH_UI=1`

------
https://chatgpt.com/codex/tasks/task_e_68562a5d315c832499b4088dff222991