### PR TITLE
Add --per-cpu option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ command name.
 Use `-i`/`--hide-idle` to start with idle processes hidden.
 Use `-H`/`--threads` to show individual threads instead of processes.
 Use `--irix` to display CPU usage relative to a single CPU.
+Use `--per-cpu` to show per-core CPU usage by default.
 
 Use `-u USER` or `-U USER` to show only processes owned by `USER`.
 

--- a/include/ui.h
+++ b/include/ui.h
@@ -35,6 +35,7 @@ enum mem_unit next_mem_unit(enum mem_unit unit);
 #ifdef WITH_UI
 void ui_set_show_full_cmd(int on);
 void ui_set_show_idle(int on);
+void ui_set_show_cores(int on);
 /* Load configuration from ~/.vtoprc if available. The delay and sort
  * parameters are updated with the loaded values. */
 int ui_load_config(unsigned int *delay_ms, enum sort_field *sort);

--- a/src/main.c
+++ b/src/main.c
@@ -45,6 +45,7 @@ static void usage(const char *prog) {
     printf("  -i, --hide-idle   Hide processes with zero CPU usage\n");
     printf("  -H, --threads     Show individual threads instead of processes\n");
     printf("      --irix        Do not scale CPU%% by number of CPUs\n");
+    printf("      --per-cpu     Show per-core CPU usage\n");
     printf("      --accum       Include child CPU time in TIME column\n");
 #ifdef WITH_UI
     printf("      --list-fields  Print column names and exit\n");
@@ -172,6 +173,7 @@ int main(int argc, char *argv[]) {
 #ifdef WITH_UI
         {"list-fields", no_argument, NULL, 2},
 #endif
+        {"per-cpu", no_argument, NULL, '1'},
         {"accum", no_argument, NULL, 1},
         {"irix", no_argument, NULL, 3},
         {"help", no_argument, NULL, 'h'},
@@ -200,6 +202,11 @@ int main(int argc, char *argv[]) {
             return 0;
         case 3:
             set_cpu_irix_mode(1);
+            break;
+        case '1':
+#ifdef WITH_UI
+            ui_set_show_cores(1);
+#endif
             break;
         case 's':
             if (strcmp(optarg, "cpu") == 0)

--- a/src/ui.c
+++ b/src/ui.c
@@ -126,6 +126,8 @@ void ui_set_show_full_cmd(int on) { show_full_cmd = on != 0; }
 
 void ui_set_show_idle(int on) { show_idle = on != 0; }
 
+void ui_set_show_cores(int on) { show_cores = on != 0; }
+
 static void apply_color_scheme(void) {
     if (!has_colors())
         return;


### PR DESCRIPTION
## Summary
- add `--per-cpu` command line flag
- expose `ui_set_show_cores()`
- enable per-core display when the flag is used
- document the new option

## Testing
- `make WITH_UI=1`
- `./vtop --help | head -n 22`

------
https://chatgpt.com/codex/tasks/task_e_6856337087948324bba29c6bedf775df