### PR TITLE
Add command filter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ The `-s` option selects the sort field. Available values are:
 The `-b`/`--batch` option runs without the ncurses interface and prints
 plain text updates. Use `-n N` to limit the number of refresh cycles;
 `0` runs indefinitely. The `-p` option restricts the output to the
-comma-separated list of PIDs given. The `-E` and `-e` options control the
+comma-separated list of PIDs given. The `-C` option filters processes by a
+substring of the command name. The `-E` and `-e` options control the
 units used when displaying memory. Both accept one of `k`, `m`, `g`, `t`,
 `p` or `e` for kilobytes through exabytes. `-E` affects the summary line
 while `-e` scales per-process values.
@@ -55,6 +56,8 @@ Use `--per-cpu` to show per-core CPU usage by default.
 Use `-V`/`--version` to print the vtop version and exit.
 
 Use `-u USER` or `-U USER` to show only processes owned by `USER`.
+Use `-C STR` or `--command-filter STR` to display only tasks whose
+command contains the given substring.
 
 ```sh
 vtop -u alice

--- a/src/main.c
+++ b/src/main.c
@@ -28,7 +28,7 @@ static enum mem_unit parse_unit(const char *arg) {
 }
 
 static void usage(const char *prog) {
-    printf("Usage: %s [-d seconds] [-S] [-a] [-i] [--accum] [-s column] [-E unit] [-e unit] [-b iter] [-n iter] [-m max] [-p pid,...] [-u user] [-U user] [-w cols]\n", prog);
+    printf("Usage: %s [-d seconds] [-S] [-a] [-i] [--accum] [-s column] [-E unit] [-e unit] [-b iter] [-n iter] [-m max] [-p pid,...] [-C string] [-u user] [-U user] [-w cols]\n", prog);
     printf("  -d, --delay SECS   Refresh delay in seconds (default 3)\n");
     printf("  -S, --secure       Disable signaling and renicing tasks\n");
     printf("  -s, --sort  COL    Sort column: pid,cpu,mem,user,start,time,pri (default pid)\n");
@@ -37,6 +37,7 @@ static void usage(const char *prog) {
     printf("  -b, --batch ITER   Batch mode iterations (0=loop forever)\n");
     printf("  -n, --iterations N Number of refresh cycles (0=run forever)\n");
     printf("  -p, --pid   LIST   Comma-separated PIDs to monitor\n");
+    printf("  -C, --command-filter STR  Show only tasks whose command contains STR\n");
     printf("  -u USER            Show only tasks owned by USER\n");
     printf("  -U USER            Same as -u\n");
     printf("  -m, --max   N     Maximum number of processes to display (0=all)\n");
@@ -165,6 +166,7 @@ int main(int argc, char *argv[]) {
         {"iterations", required_argument, NULL, 'n'},
         {"max", required_argument, NULL, 'm'},
         {"pid", required_argument, NULL, 'p'},
+        {"command-filter", required_argument, NULL, 'C'},
         {"user", required_argument, NULL, 'u'},
         {"euser", required_argument, NULL, 'U'},
         {"width", required_argument, NULL, 'w'},
@@ -186,7 +188,7 @@ int main(int argc, char *argv[]) {
     int batch = 0;
     unsigned int iterations = 0;
     int columns = 0;
-    while ((opt = getopt_long(argc, argv, "d:Ss:E:e:b:n:m:p:u:U:w:aiHVh", long_opts, &idx)) != -1) {
+    while ((opt = getopt_long(argc, argv, "d:Ss:E:e:b:n:m:p:C:u:U:w:aiHVh", long_opts, &idx)) != -1) {
         switch (opt) {
         case 'd':
             delay_ms = (unsigned int)(strtod(optarg, NULL) * 1000);
@@ -245,6 +247,9 @@ int main(int argc, char *argv[]) {
             break;
         case 'p':
             set_pid_filter(optarg);
+            break;
+        case 'C':
+            set_name_filter(optarg);
             break;
         case 'u':
         case 'U':

--- a/vtopdoc.md
+++ b/vtopdoc.md
@@ -76,6 +76,8 @@ monitoring tools without requiring additional dependencies.
 - `-i`/`--hide-idle` &mdash; Do not list tasks with zero CPU usage.
 - `--irix` &mdash; Display per-process CPU usage relative to one CPU.
 - `-u USER`, `-U USER` &mdash; Show only processes owned by `USER`.
+- `-C STR`, `--command-filter STR` &mdash; Show only tasks whose command
+  contains `STR`.
 
 Examples:
 
@@ -88,6 +90,7 @@ vtop --accum      # include child CPU time in display
 vtop -a           # show full command line at startup
 vtop -i           # hide idle processes on launch
 vtop -u alice     # show only tasks owned by alice
+vtop -C ssh       # display only commands containing "ssh"
 ```
 
 The interactive display lists PID, USER, command name, state,


### PR DESCRIPTION
## Summary
- add `-C`/`--command-filter` to filter by command substring
- hook up to `set_name_filter`
- document new option in README and vtopdoc

## Testing
- `make WITH_UI=1`
- `./vtop -h | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_685635131e5c8324ba66f9141160764a