### PR TITLE
Add CPU column

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Additional shortcuts:
 - Press `space` to pause or resume updates.
 - Press `h` to open a small help window with available shortcuts.
 - Press `W` to save the current configuration.
-- Press `f` to open the field manager. Use `space` to toggle visibility and
-  `h`/`l` to move the selected column left or right.
+- Press `f` to open the field manager. Use `space` to toggle visibility,
+including the new CPU column, and `h`/`l` to move the selected column left or right.
 
 These controls operate on live processes. Ensure you have permission to
 signal or renice the target process. Running as root can terminate or slow
@@ -109,7 +109,7 @@ configuration manually.
 
 Example output with the ncurses interface:
 
-The table shows PID, USER, process name, state, priority,
+The table shows PID, CPU, USER, process name, state, priority,
 nice value, virtual memory size, resident set size, memory
 usage percentage, CPU usage, total CPU time and the process
 start time.

--- a/include/proc.h
+++ b/include/proc.h
@@ -87,6 +87,8 @@ struct process_info {
     double start_timestamp;
     /* Process start time as HH:MM:SS */
     char start_time[16];
+    /* Processor this task last ran on */
+    int cpu;
     /* Nesting level for forest view */
     int level;
 };

--- a/src/main.c
+++ b/src/main.c
@@ -129,13 +129,13 @@ static int run_batch(unsigned int delay_ms, enum sort_field sort,
                100.0 - cs.idle_percent, cs.user_percent, cs.system_percent,
                cs.idle_percent, mem_usage, swap_used, swap_total,
                mem_unit_suffix(summary_unit), swap_usage, delay_ms / 1000.0);
-        printf("PID      USER     NAME                     STATE PRI  NICE  VSIZE    RSS  RSS%%  CPU%%   TIME     START\n");
+        printf("PID      CPU  USER     NAME                     STATE PRI  NICE  VSIZE    RSS  RSS%%  CPU%%   TIME     START\n");
         for (size_t i = 0; i < count; i++) {
             double vsz = procs[i].vsize / 1024.0; /* bytes to KB */
             vsz = scale_kb((unsigned long long)vsz, proc_unit);
             double rss = scale_kb((unsigned long long)procs[i].rss, proc_unit);
-            printf("%-8d %-8s %-25s %c %4ld %5ld %8.1f %5.1f %6.2f %6.2f %8.0f %-8s\n",
-                   procs[i].pid, procs[i].user, procs[i].name, procs[i].state,
+            printf("%-8d %3d %-8s %-25s %c %4ld %5ld %8.1f %5.1f %6.2f %6.2f %8.0f %-8s\n",
+                   procs[i].pid, procs[i].cpu, procs[i].user, procs[i].name, procs[i].state,
                    procs[i].priority, procs[i].nice, vsz, rss,
                    procs[i].rss_percent, procs[i].cpu_usage,
                    procs[i].cpu_time, procs[i].start_time);

--- a/src/proc.c
+++ b/src/proc.c
@@ -397,10 +397,12 @@ size_t list_processes(struct process_info *buf, size_t max) {
                     long priority, niceval;
                     unsigned long long vsize;
                     long rss;
+                    int cpu = 0;
                     sscanf(line,
-                           "%*d (%255[^)]) %c %d %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %llu %llu %llu %llu %ld %ld %*s %*s %llu %llu %ld",
+                           "%*d (%255[^)]) %c %d %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %llu %llu %llu %llu %ld %ld %*s %*s %llu %llu %ld"
+                           " %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %d",
                            comm, &state, &ppid, &utime, &stime, &cutime, &cstime,
-                           &priority, &niceval, &starttime, &vsize, &rss);
+                           &priority, &niceval, &starttime, &vsize, &rss, &cpu);
 
                     unsigned int uid = 0;
                     snprintf(path, sizeof(path), "/proc/%ld/status", pid);
@@ -513,6 +515,7 @@ size_t list_processes(struct process_info *buf, size_t max) {
                         strncpy(buf[count].start_time, "??:??:??",
                                 sizeof(buf[count].start_time));
                     buf[count].start_timestamp = (double)start_epoch;
+                    buf[count].cpu = cpu;
                     buf[count].level = 0;
                     count++;
                 }
@@ -534,10 +537,12 @@ size_t list_processes(struct process_info *buf, size_t max) {
                 long priority, niceval;
                 unsigned long long vsize;
                 long rss;
+                int cpu = 0;
                 sscanf(line,
-                       "%*d (%255[^)]) %c %d %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %llu %llu %llu %llu %ld %ld %*s %*s %llu %llu %ld",
+                       "%*d (%255[^)]) %c %d %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %llu %llu %llu %llu %ld %ld %*s %*s %llu %llu %ld"
+                       " %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %d",
                        comm, &state, &ppid, &utime, &stime, &cutime, &cstime,
-                       &priority, &niceval, &starttime, &vsize, &rss);
+                       &priority, &niceval, &starttime, &vsize, &rss, &cpu);
 
                 unsigned int uid = 0;
                 snprintf(path, sizeof(path), "/proc/%ld/status", pid);
@@ -650,6 +655,7 @@ size_t list_processes(struct process_info *buf, size_t max) {
                     strncpy(buf[count].start_time, "??:??:??",
                             sizeof(buf[count].start_time));
                 buf[count].start_timestamp = (double)start_epoch;
+                buf[count].cpu = cpu;
                 buf[count].level = 0;
                 count++;
             }

--- a/src/ui.c
+++ b/src/ui.c
@@ -60,6 +60,7 @@ enum column_id {
     COL_VSIZE,
     COL_RSS,
     COL_RSSP,
+    COL_CPU,
     COL_CPUP,
     COL_TIME,
     COL_START,
@@ -88,9 +89,10 @@ static struct column_def columns[COL_COUNT] = {
     {COL_VSIZE, "VSIZE",   8, 0, 1, 7},
     {COL_RSS,   "RSS",     5, 0, 1, 8},
     {COL_RSSP,  "RSS%",    6, 0, 1, 9},
-    {COL_CPUP,  "CPU%",    6, 0, 1,10},
-    {COL_TIME,  "TIME",    8, 0, 1,11},
-    {COL_START, "START",   8, 1, 1,12}
+    {COL_CPU,   "CPU",     3, 0, 1,10},
+    {COL_CPUP,  "CPU%",    6, 0, 1,11},
+    {COL_TIME,  "TIME",    8, 0, 1,12},
+    {COL_START, "START",   8, 1, 1,13}
 };
 
 void ui_list_fields(void) {
@@ -413,6 +415,10 @@ static void draw_process_row(int row, const struct process_info *p) {
         case COL_RSSP:
             mvprintw(row, x, columns[i].left ? "%-*.2f" : "%*.2f",
                      columns[i].width, p->rss_percent);
+            break;
+        case COL_CPU:
+            mvprintw(row, x, columns[i].left ? "%-*d" : "%*d",
+                     columns[i].width, p->cpu);
             break;
         case COL_CPUP:
             mvprintw(row, x, columns[i].left ? "%-*.2f" : "%*.2f",

--- a/vtopdoc.md
+++ b/vtopdoc.md
@@ -93,7 +93,7 @@ vtop -u alice     # show only tasks owned by alice
 vtop -C ssh       # display only commands containing "ssh"
 ```
 
-The interactive display lists PID, USER, command name, state,
+The interactive display lists PID, CPU, USER, command name, state,
 priority, nice value, virtual memory size, resident set size,
 memory usage percentage, CPU usage, total CPU time and the process
 start time.
@@ -114,8 +114,8 @@ Process management shortcuts are also available:
 - `B` &ndash; sort by start time.
 - `M` &ndash; sort by memory usage.
 - `h` &ndash; display a help window showing available shortcuts.
-- `f` &ndash; open the field manager to hide columns or reorder them
-  with `h`/`l`.
+- `f` &ndash; open the field manager to hide columns or reorder them,
+  including the CPU column, with `h`/`l`.
 
 Use caution when running with elevated privileges because killing or
 renicing critical processes can destabilize the system.


### PR DESCRIPTION
## Summary
- add `cpu` field to `struct process_info`
- parse processor number in `list_processes()`
- show CPU number column in the UI and batch mode
- document the new column and update field manager instructions

## Testing
- `make WITH_UI=1`

------
https://chatgpt.com/codex/tasks/task_e_68570e86bbb08324a51b4b0057c0d2a1