### PR TITLE
Add SHR column to display shared memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Additional shortcuts:
 - Press `h` to open a small help window with available shortcuts.
 - Press `W` to save the current configuration.
 - Press `f` to open the field manager. Use `space` to toggle visibility,
-including the new CPU column, and `h`/`l` to move the selected column left or right.
+including the CPU and SHR columns, and `h`/`l` to move the selected column left or right.
 
 These controls operate on live processes. Ensure you have permission to
 signal or renice the target process. Running as root can terminate or slow
@@ -110,9 +110,9 @@ configuration manually.
 Example output with the ncurses interface:
 
 The table shows PID, CPU, USER, process name, state, priority,
-nice value, virtual memory size, resident set size, memory
-usage percentage, CPU usage, total CPU time and the process
-start time.
+nice value, virtual memory size, resident set size, shared
+memory size, memory usage percentage, CPU usage, total CPU time
+and the process start time.
 The header above the table displays the system load averages,
 uptime and a full task state summary in the form
 `tasks <total> total, <running> running, <sleeping> sleeping,
@@ -121,7 +121,7 @@ uptime and a full task state summary in the form
 ```text
 $ vtop
 load 0.00 0.01 0.05  up 1234s  tasks 87 total, 1 running, 86 sleeping, 0 stopped, 0 zombie  cpu 2.0%  mem 27.3%
-PID      NAME                     STATE  VSIZE    RSS  RSS%  CPU%   TIME     START
+PID      NAME                     STATE  VSIZE    RSS   SHR  RSS%  CPU%   TIME     START
 ...
 ```
 

--- a/include/proc.h
+++ b/include/proc.h
@@ -74,6 +74,8 @@ struct process_info {
     long nice;
     unsigned long long vsize;
     long rss;
+    /* Shared memory size in KB */
+    unsigned long long shared;
     /* RSS as a percentage of total system memory */
     double rss_percent;
     /* User and system CPU times in clock ticks */

--- a/src/main.c
+++ b/src/main.c
@@ -129,14 +129,15 @@ static int run_batch(unsigned int delay_ms, enum sort_field sort,
                100.0 - cs.idle_percent, cs.user_percent, cs.system_percent,
                cs.idle_percent, mem_usage, swap_used, swap_total,
                mem_unit_suffix(summary_unit), swap_usage, delay_ms / 1000.0);
-        printf("PID      CPU  USER     NAME                     STATE PRI  NICE  VSIZE    RSS  RSS%%  CPU%%   TIME     START\n");
+        printf("PID      CPU  USER     NAME                     STATE PRI  NICE  VSIZE    RSS   SHR  RSS%%  CPU%%   TIME     START\n");
         for (size_t i = 0; i < count; i++) {
             double vsz = procs[i].vsize / 1024.0; /* bytes to KB */
             vsz = scale_kb((unsigned long long)vsz, proc_unit);
             double rss = scale_kb((unsigned long long)procs[i].rss, proc_unit);
-            printf("%-8d %3d %-8s %-25s %c %4ld %5ld %8.1f %5.1f %6.2f %6.2f %8.0f %-8s\n",
+            double shr = scale_kb(procs[i].shared, proc_unit);
+            printf("%-8d %3d %-8s %-25s %c %4ld %5ld %8.1f %5.1f %5.1f %6.2f %6.2f %8.0f %-8s\n",
                    procs[i].pid, procs[i].cpu, procs[i].user, procs[i].name, procs[i].state,
-                   procs[i].priority, procs[i].nice, vsz, rss,
+                   procs[i].priority, procs[i].nice, vsz, rss, shr,
                    procs[i].rss_percent, procs[i].cpu_usage,
                    procs[i].cpu_time, procs[i].start_time);
         }

--- a/src/proc.c
+++ b/src/proc.c
@@ -496,6 +496,16 @@ size_t list_processes(struct process_info *buf, size_t max) {
                     buf[count].vsize = vsize;
                     long rss_kb = rss * page_kb;
                     buf[count].rss = rss_kb;
+                    unsigned long long shared_kb = 0;
+                    snprintf(path, sizeof(path), "/proc/%ld/statm", pid);
+                    FILE *fm = fopen(path, "r");
+                    if (fm) {
+                        unsigned long dummy, res, shr;
+                        if (fscanf(fm, "%lu %lu %lu", &dummy, &res, &shr) >= 3)
+                            shared_kb = shr * page_kb;
+                        fclose(fm);
+                    }
+                    buf[count].shared = shared_kb;
                     buf[count].rss_percent = 100.0 * (double)rss_kb /
                                            (double)ms.total;
                     buf[count].utime = utime;
@@ -636,6 +646,16 @@ size_t list_processes(struct process_info *buf, size_t max) {
                 buf[count].vsize = vsize;
                 long rss_kb = rss * page_kb;
                 buf[count].rss = rss_kb;
+                unsigned long long shared_kb = 0;
+                snprintf(path, sizeof(path), "/proc/%ld/statm", pid);
+                FILE *fm = fopen(path, "r");
+                if (fm) {
+                    unsigned long dummy, res, shr;
+                    if (fscanf(fm, "%lu %lu %lu", &dummy, &res, &shr) >= 3)
+                        shared_kb = shr * page_kb;
+                    fclose(fm);
+                }
+                buf[count].shared = shared_kb;
                 buf[count].rss_percent = 100.0 * (double)rss_kb /
                                        (double)ms.total;
                 buf[count].utime = utime;

--- a/src/ui.c
+++ b/src/ui.c
@@ -59,6 +59,7 @@ enum column_id {
     COL_NICE,
     COL_VSIZE,
     COL_RSS,
+    COL_SHR,
     COL_RSSP,
     COL_CPU,
     COL_CPUP,
@@ -88,11 +89,12 @@ static struct column_def columns[COL_COUNT] = {
     {COL_NICE,  "NICE",    5, 0, 1, 6},
     {COL_VSIZE, "VSIZE",   8, 0, 1, 7},
     {COL_RSS,   "RSS",     5, 0, 1, 8},
-    {COL_RSSP,  "RSS%",    6, 0, 1, 9},
-    {COL_CPU,   "CPU",     3, 0, 1,10},
-    {COL_CPUP,  "CPU%",    6, 0, 1,11},
-    {COL_TIME,  "TIME",    8, 0, 1,12},
-    {COL_START, "START",   8, 1, 1,13}
+    {COL_SHR,   "SHR",     5, 0, 1, 9},
+    {COL_RSSP,  "RSS%",    6, 0, 1,10},
+    {COL_CPU,   "CPU",     3, 0, 1,11},
+    {COL_CPUP,  "CPU%",    6, 0, 1,12},
+    {COL_TIME,  "TIME",    8, 0, 1,13},
+    {COL_START, "START",   8, 1, 1,14}
 };
 
 void ui_list_fields(void) {
@@ -412,6 +414,12 @@ static void draw_process_row(int row, const struct process_info *p) {
                      columns[i].width, rss);
             break;
         }
+        case COL_SHR: {
+            double shr = scale_kb(p->shared, proc_unit);
+            mvprintw(row, x, columns[i].left ? "%-*.1f" : "%*.1f",
+                     columns[i].width, shr);
+            break;
+        }
         case COL_RSSP:
             mvprintw(row, x, columns[i].left ? "%-*.2f" : "%*.2f",
                      columns[i].width, p->rss_percent);
@@ -543,7 +551,7 @@ static void show_help(void) {
     mvwprintw(win, 28, 2, "E       Cycle memory units");
     mvwprintw(win, 29, 2, "t       Toggle CPU summary");
     mvwprintw(win, 30, 2, "m       Toggle memory summary");
-    mvwprintw(win, 31, 2, "f       Field manager");
+    mvwprintw(win, 31, 2, "f       Field manager (toggle columns)");
     mvwprintw(win, 32, 2, "n       Set entry limit");
     mvwprintw(win, 33, 2, "W       Save config");
     mvwprintw(win, 34, 2, "SPACE    Pause/resume");


### PR DESCRIPTION
## Summary
- track shared memory usage in process_info
- read `/proc/[pid]/statm` for shared pages and convert to KB
- display shared memory column in UI and batch modes
- describe SHR column in README and help text

## Testing
- `make clean >/tmp/make.log && make WITH_UI=1 >>/tmp/make.log`


------
https://chatgpt.com/codex/tasks/task_e_685710310a9c83249a58456d60104f0e