### PR TITLE
Add VSIZE sorting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The `-s` option selects the sort field. Available values are:
 - `pid` &ndash; sort by process ID
 - `cpu` &ndash; sort by CPU usage
 - `mem` &ndash; sort by memory usage
+- `vsize` &ndash; sort by virtual memory size
 - `user` &ndash; sort by username
 - `start` &ndash; sort by start time
 

--- a/include/proc.h
+++ b/include/proc.h
@@ -115,6 +115,7 @@ const char *get_pid_filter(void);
 int cmp_proc_pid(const void *a, const void *b);
 int cmp_proc_cpu(const void *a, const void *b);
 int cmp_proc_mem(const void *a, const void *b);
+int cmp_proc_vsize(const void *a, const void *b);
 int cmp_proc_time(const void *a, const void *b);
 int cmp_proc_priority(const void *a, const void *b);
 int cmp_proc_user(const void *a, const void *b);

--- a/include/ui.h
+++ b/include/ui.h
@@ -7,6 +7,7 @@ enum sort_field {
     SORT_PID,
     SORT_CPU,
     SORT_MEM,
+    SORT_VSIZE,
     SORT_USER,
     SORT_START,
     SORT_TIME,

--- a/src/main.c
+++ b/src/main.c
@@ -31,7 +31,7 @@ static void usage(const char *prog) {
     printf("Usage: %s [-d seconds] [-S] [-a] [-i] [--accum] [-s column] [-E unit] [-e unit] [-b iter] [-n iter] [-m max] [-p pid,...] [-C string] [-u user] [-U user] [-w cols]\n", prog);
     printf("  -d, --delay SECS   Refresh delay in seconds (default 3)\n");
     printf("  -S, --secure       Disable signaling and renicing tasks\n");
-    printf("  -s, --sort  COL    Sort column: pid,cpu,mem,user,start,time,pri (default pid)\n");
+    printf("  -s, --sort  COL    Sort column: pid,cpu,mem,vsize,user,start,time,pri (default pid)\n");
     printf("  -E, --scale-summary-mem UNIT  Memory units for summary (k,m,g,t,p,e)\n");
     printf("  -e, --scale-task-mem UNIT     Memory units for processes (k,m,g,t,p,e)\n");
     printf("  -b, --batch ITER   Batch mode iterations (0=loop forever)\n");
@@ -69,6 +69,10 @@ static int run_batch(unsigned int delay_ms, enum sort_field sort,
         break;
     case SORT_MEM:
         compare = cmp_proc_mem;
+        set_sort_descending(1);
+        break;
+    case SORT_VSIZE:
+        compare = cmp_proc_vsize;
         set_sort_descending(1);
         break;
     case SORT_USER:
@@ -218,6 +222,8 @@ int main(int argc, char *argv[]) {
                 sort = SORT_CPU;
             else if (strcmp(optarg, "mem") == 0)
                 sort = SORT_MEM;
+            else if (strcmp(optarg, "vsize") == 0)
+                sort = SORT_VSIZE;
             else if (strcmp(optarg, "user") == 0)
                 sort = SORT_USER;
             else if (strcmp(optarg, "start") == 0)

--- a/src/proc.c
+++ b/src/proc.c
@@ -806,6 +806,19 @@ int cmp_proc_mem(const void *a, const void *b) {
     return res;
 }
 
+int cmp_proc_vsize(const void *a, const void *b) {
+    const struct process_info *pa = a;
+    const struct process_info *pb = b;
+    int res = 0;
+    if (pa->vsize < pb->vsize)
+        res = -1;
+    else if (pa->vsize > pb->vsize)
+        res = 1;
+    if (sort_descending)
+        res = -res;
+    return res;
+}
+
 int cmp_proc_time(const void *a, const void *b) {
     const struct process_info *pa = a;
     const struct process_info *pb = b;

--- a/src/ui.c
+++ b/src/ui.c
@@ -168,6 +168,8 @@ int ui_load_config(unsigned int *delay_ms, enum sort_field *sort) {
                     *sort = SORT_CPU;
                 else if (strcmp(val, "mem") == 0)
                     *sort = SORT_MEM;
+                else if (strcmp(val, "vsize") == 0)
+                    *sort = SORT_VSIZE;
                 else if (strcmp(val, "user") == 0)
                     *sort = SORT_USER;
                 else if (strcmp(val, "start") == 0)
@@ -247,6 +249,8 @@ int ui_save_config(unsigned int delay_ms, enum sort_field sort) {
         s = "cpu";
     else if (sort == SORT_MEM)
         s = "mem";
+    else if (sort == SORT_VSIZE)
+        s = "vsize";
     else if (sort == SORT_USER)
         s = "user";
     else if (sort == SORT_START)
@@ -313,6 +317,8 @@ static enum column_id get_sort_column(void) {
         return COL_CPUP;
     case SORT_MEM:
         return COL_RSS;
+    case SORT_VSIZE:
+        return COL_VSIZE;
     case SORT_USER:
         return COL_USER;
     case SORT_START:
@@ -579,6 +585,10 @@ static void set_sort(enum sort_field sort) {
         break;
     case SORT_MEM:
         compare_procs = cmp_proc_mem;
+        set_sort_descending(1);
+        break;
+    case SORT_VSIZE:
+        compare_procs = cmp_proc_vsize;
         set_sort_descending(1);
         break;
     case SORT_USER:

--- a/vtopdoc.md
+++ b/vtopdoc.md
@@ -66,7 +66,7 @@ monitoring tools without requiring additional dependencies.
 - `-d SECS` &mdash; Set the refresh delay in seconds. The default is
   `3` seconds just like `top`.
 - `-s COL` &mdash; Choose the column to sort by. Supported values are
-  `pid`, `cpu`, `mem`, `user` and `start`. The default is `pid`.
+  `pid`, `cpu`, `mem`, `vsize`, `user` and `start`. The default is `pid`.
 - `-S` &mdash; Enable secure mode which disables signaling and renicing
   processes.
 - `--accum` &mdash; Include child CPU time when displaying `TIME`.


### PR DESCRIPTION
## Summary
- support sorting by virtual memory size
- handle VSIZE in configuration and arguments
- document `vsize` sort option in CLI usage and README

## Testing
- `make`
- `make WITH_UI=1`


------
https://chatgpt.com/codex/tasks/task_e_685cd5c4e12c8324b5ede474f23fd6e1