### PR TITLE
Add process state filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Use `-V`/`--version` to print the vtop version and exit.
 Use `-u USER` or `-U USER` to show only processes owned by `USER`.
 Use `-C STR` or `--command-filter STR` to display only tasks whose
 command contains the given substring.
+Use `--state=R` to display only tasks in state `R` (running). Use an empty
+argument to clear the filter.
 
 ```sh
 vtop -u alice
@@ -78,6 +80,7 @@ Additional shortcuts:
 - Press `a` to toggle between the short command name and the full command line.
 - Press `H` to toggle thread view (show individual threads).
 - Press `i` to hide or show processes with zero CPU usage.
+- Press `g` to filter by process state (e.g., `R` for running).
 - Press `Z` to cycle through color schemes.
 - Press `x` to toggle highlighting of the sorted column.
 - Press `b` to toggle bold text in the process list.

--- a/include/proc.h
+++ b/include/proc.h
@@ -141,4 +141,8 @@ int get_show_accum_time(void);
 void set_cpu_irix_mode(int on);
 int get_cpu_irix_mode(void);
 
+/* process state filter */
+void set_state_filter(char state);
+char get_state_filter(void);
+
 #endif /* PROC_H */

--- a/src/main.c
+++ b/src/main.c
@@ -38,6 +38,7 @@ static void usage(const char *prog) {
     printf("  -n, --iterations N Number of refresh cycles (0=run forever)\n");
     printf("  -p, --pid   LIST   Comma-separated PIDs to monitor\n");
     printf("  -C, --command-filter STR  Show only tasks whose command contains STR\n");
+    printf("      --state STATE   Show only tasks in the given state\n");
     printf("  -u USER            Show only tasks owned by USER\n");
     printf("  -U USER            Same as -u\n");
     printf("  -m, --max   N     Maximum number of processes to display (0=all)\n");
@@ -184,6 +185,7 @@ int main(int argc, char *argv[]) {
         {"per-cpu", no_argument, NULL, '1'},
         {"accum", no_argument, NULL, 1},
         {"irix", no_argument, NULL, 3},
+        {"state", required_argument, NULL, 4},
         {"version", no_argument, NULL, 'V'},
         {"help", no_argument, NULL, 'h'},
         {NULL, 0, NULL, 0}
@@ -211,6 +213,12 @@ int main(int argc, char *argv[]) {
             return 0;
         case 3:
             set_cpu_irix_mode(1);
+            break;
+        case 4:
+            if (optarg && *optarg)
+                set_state_filter(optarg[0]);
+            else
+                set_state_filter('\0');
             break;
         case '1':
 #ifdef WITH_UI

--- a/src/proc.c
+++ b/src/proc.c
@@ -39,6 +39,7 @@ static int thread_mode;
 static int show_idle = 1;
 static int show_accum_time;
 static int cpu_irix_mode;
+static char state_filter;
 
 void set_sort_descending(int desc) { sort_descending = desc != 0; }
 int get_sort_descending(void) { return sort_descending; }
@@ -54,6 +55,9 @@ int get_show_accum_time(void) { return show_accum_time; }
 
 void set_cpu_irix_mode(int on) { cpu_irix_mode = on != 0; }
 int get_cpu_irix_mode(void) { return cpu_irix_mode; }
+
+void set_state_filter(char state) { state_filter = state; }
+char get_state_filter(void) { return state_filter; }
 
 void set_name_filter(const char *substr) {
     if (substr && *substr) {
@@ -100,7 +104,7 @@ size_t get_cpu_core_count(void) { return core_count; }
 
 const struct cpu_core_stats *get_cpu_core_stats(void) { return core_stats; }
 
-static int match_filter(int pid, const char *name, const char *user) {
+static int match_filter(int pid, const char *name, const char *user, char state) {
     if (pid_list_count > 0) {
         int found = 0;
         for (size_t i = 0; i < pid_list_count; i++) {
@@ -113,6 +117,8 @@ static int match_filter(int pid, const char *name, const char *user) {
             return 0;
     }
     if (user_filter[0] && strcmp(user_filter, user) != 0)
+        return 0;
+    if (state_filter && state_filter != state)
         return 0;
     if (name_filter[0]) {
         /* simple case-insensitive substring search */
@@ -485,7 +491,7 @@ size_t list_processes(struct process_info *buf, size_t max) {
                         buf[count].cmdline[0] = '\0';
                     }
 
-                    if (!match_filter((int)pid, buf[count].name, buf[count].user)) {
+                    if (!match_filter((int)pid, buf[count].name, buf[count].user, state)) {
                         fclose(fp);
                         continue;
                     }
@@ -635,7 +641,7 @@ size_t list_processes(struct process_info *buf, size_t max) {
                     buf[count].cmdline[0] = '\0';
                 }
 
-                if (!match_filter((int)pid, buf[count].name, buf[count].user)) {
+                if (!match_filter((int)pid, buf[count].name, buf[count].user, state)) {
                     fclose(fp);
                     continue;
                 }

--- a/src/ui.c
+++ b/src/ui.c
@@ -518,7 +518,7 @@ static void field_manager(void) {
 }
 
 static void show_help(void) {
-    const int h = 40;
+    const int h = 41;
     const int w = 52;
     int startx = COLS > w ? (COLS - w) / 2 : 0;
     if (startx < 0)
@@ -542,28 +542,29 @@ static void show_help(void) {
     mvwprintw(win, 13, 2, "d/s     Set refresh delay");
     mvwprintw(win, 14, 2, "/       Filter by command name");
     mvwprintw(win, 15, 2, "u       Filter by user");
-    mvwprintw(win, 16, 2, "k       Send signal to a process");
-    mvwprintw(win, 17, 2, "r       Renice a process");
-    mvwprintw(win, 18, 2, "c       Toggle per-core view");
-    mvwprintw(win, 19, 2, "a       Toggle full command");
-    mvwprintw(win, 20, 2, "H       Toggle thread view");
-    mvwprintw(win, 21, 2, "i       Toggle idle processes");
-    mvwprintw(win, 22, 2, "V       Toggle process tree");
-    mvwprintw(win, 23, 2, "Z       Cycle color scheme");
-    mvwprintw(win, 24, 2, "x       Toggle sort highlight");
-    mvwprintw(win, 25, 2, "b       Toggle bold text");
-    mvwprintw(win, 26, 2, "S       Toggle cumulative time");
-    mvwprintw(win, 27, 2, "I       Toggle Irix mode");
-    mvwprintw(win, 28, 2, "E       Cycle memory units");
-    mvwprintw(win, 29, 2, "t       Toggle CPU summary");
-    mvwprintw(win, 30, 2, "m       Toggle memory summary");
-    mvwprintw(win, 31, 2, "f       Field manager (toggle columns)");
-    mvwprintw(win, 32, 2, "n       Set entry limit");
-    mvwprintw(win, 33, 2, "W       Save config");
-    mvwprintw(win, 34, 2, "UP/DOWN  Scroll one line");
-    mvwprintw(win, 35, 2, "PgUp/PgDn Scroll a page");
-    mvwprintw(win, 36, 2, "SPACE    Pause/resume");
-    mvwprintw(win, 37, 2, "h       Show this help");
+    mvwprintw(win, 16, 2, "g       Filter by state");
+    mvwprintw(win, 17, 2, "k       Send signal to a process");
+    mvwprintw(win, 18, 2, "r       Renice a process");
+    mvwprintw(win, 19, 2, "c       Toggle per-core view");
+    mvwprintw(win, 20, 2, "a       Toggle full command");
+    mvwprintw(win, 21, 2, "H       Toggle thread view");
+    mvwprintw(win, 22, 2, "i       Toggle idle processes");
+    mvwprintw(win, 23, 2, "V       Toggle process tree");
+    mvwprintw(win, 24, 2, "Z       Cycle color scheme");
+    mvwprintw(win, 25, 2, "x       Toggle sort highlight");
+    mvwprintw(win, 26, 2, "b       Toggle bold text");
+    mvwprintw(win, 27, 2, "S       Toggle cumulative time");
+    mvwprintw(win, 28, 2, "I       Toggle Irix mode");
+    mvwprintw(win, 29, 2, "E       Cycle memory units");
+    mvwprintw(win, 30, 2, "t       Toggle CPU summary");
+    mvwprintw(win, 31, 2, "m       Toggle memory summary");
+    mvwprintw(win, 32, 2, "f       Field manager (toggle columns)");
+    mvwprintw(win, 33, 2, "n       Set entry limit");
+    mvwprintw(win, 34, 2, "W       Save config");
+    mvwprintw(win, 35, 2, "UP/DOWN  Scroll one line");
+    mvwprintw(win, 36, 2, "PgUp/PgDn Scroll a page");
+    mvwprintw(win, 37, 2, "SPACE    Pause/resume");
+    mvwprintw(win, 38, 2, "h       Show this help");
     mvwprintw(win, h - 2, 2, "Press any key to return");
     wrefresh(win);
     nodelay(stdscr, FALSE);
@@ -907,6 +908,20 @@ int run_ui(unsigned int delay_ms, enum sort_field sort,
             mvprintw(LINES - 1, 0, "User filter: ");
             getnstr(buf, sizeof(buf) - 1);
             set_user_filter(buf[0] ? buf : NULL);
+            noecho();
+            curs_set(0);
+            nodelay(stdscr, TRUE);
+        } else if (ch == 'g') {
+            char buf[8];
+            nodelay(stdscr, FALSE);
+            echo();
+            curs_set(1);
+            mvprintw(LINES - 1, 0, "State filter: ");
+            getnstr(buf, sizeof(buf) - 1);
+            if (buf[0])
+                set_state_filter(buf[0]);
+            else
+                set_state_filter('\0');
             noecho();
             curs_set(0);
             nodelay(stdscr, TRUE);

--- a/vtopdoc.md
+++ b/vtopdoc.md
@@ -78,6 +78,7 @@ monitoring tools without requiring additional dependencies.
 - `-u USER`, `-U USER` &mdash; Show only processes owned by `USER`.
 - `-C STR`, `--command-filter STR` &mdash; Show only tasks whose command
   contains `STR`.
+- `--state=R` &mdash; Show only tasks in state `R`.
 
 Examples:
 
@@ -107,6 +108,7 @@ Process management shortcuts are also available:
 - `c` &ndash; toggle per-core CPU usage display.
 - `a` &ndash; toggle between the short name and full command line.
 - `S` &ndash; toggle cumulative CPU time display.
+- `g` &ndash; filter processes by state (enter a letter like `R`).
 - `I` &ndash; toggle Irix mode (CPU usage of each task not divided by CPU count).
 - `F4`/`o` &ndash; change the sort direction.
 - `x` &ndash; toggle highlighting of the sorted column.


### PR DESCRIPTION
## Summary
- support filtering by task state in proc module
- parse `--state` option in main
- allow toggling state filter via `g` key in UI and document option
- update documentation and help text

## Testing
- `make WITH_UI=1`
- `./vtop --help`


------
https://chatgpt.com/codex/tasks/task_e_685ce264c1ec8324a5b82d3bf242f2b5