### PR TITLE
Add disk I/O statistics columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Additional shortcuts:
 - Press `h` to open a small help window with available shortcuts.
 - Press `W` to save the current configuration.
 - Press `f` to open the field manager. Use `space` to toggle visibility,
-including the CPU and SHR columns, and `h`/`l` to move the selected column left or right.
+including the CPU, SHR, READ and WRITE columns, and `h`/`l` to move the selected column left or right.
 
 These controls operate on live processes. Ensure you have permission to
 signal or renice the target process. Running as root can terminate or slow
@@ -115,8 +115,8 @@ Example output with the ncurses interface:
 
 The table shows PID, CPU, USER, process name, state, priority,
 nice value, virtual memory size, resident set size, shared
-memory size, memory usage percentage, CPU usage, total CPU time
-and the process start time.
+memory size, memory usage percentage, CPU usage, total CPU time,
+bytes read from and written to storage and the process start time.
 The header above the table displays the system load averages,
 uptime and a full task state summary in the form
 `tasks <total> total, <running> running, <sleeping> sleeping,

--- a/include/proc.h
+++ b/include/proc.h
@@ -85,6 +85,10 @@ struct process_info {
     double cpu_usage;
     /* Total CPU time in seconds */
     double cpu_time;
+    /* Bytes read from storage */
+    unsigned long long read_bytes;
+    /* Bytes written to storage */
+    unsigned long long write_bytes;
     /* Process start time as seconds since the epoch */
     double start_timestamp;
     /* Process start time as HH:MM:SS */

--- a/src/proc.c
+++ b/src/proc.c
@@ -514,6 +514,21 @@ size_t list_processes(struct process_info *buf, size_t max) {
                     buf[count].shared = shared_kb;
                     buf[count].rss_percent = 100.0 * (double)rss_kb /
                                            (double)ms.total;
+                    unsigned long long rb = 0, wb = 0;
+                    snprintf(path, sizeof(path), "/proc/%ld/task/%ld/io", pid, tid);
+                    FILE *fio = fopen(path, "r");
+                    if (fio) {
+                        char lineio[256];
+                        while (fgets(lineio, sizeof(lineio), fio)) {
+                            if (sscanf(lineio, "read_bytes: %llu", &rb) == 1)
+                                continue;
+                            if (sscanf(lineio, "write_bytes: %llu", &wb) == 1)
+                                continue;
+                        }
+                        fclose(fio);
+                    }
+                    buf[count].read_bytes = rb;
+                    buf[count].write_bytes = wb;
                     buf[count].utime = utime;
                     buf[count].stime = stime;
                     buf[count].cpu_usage = usage;
@@ -664,6 +679,21 @@ size_t list_processes(struct process_info *buf, size_t max) {
                 buf[count].shared = shared_kb;
                 buf[count].rss_percent = 100.0 * (double)rss_kb /
                                        (double)ms.total;
+                unsigned long long rb = 0, wb = 0;
+                snprintf(path, sizeof(path), "/proc/%ld/io", pid);
+                FILE *fio = fopen(path, "r");
+                if (fio) {
+                    char lineio[256];
+                    while (fgets(lineio, sizeof(lineio), fio)) {
+                        if (sscanf(lineio, "read_bytes: %llu", &rb) == 1)
+                            continue;
+                        if (sscanf(lineio, "write_bytes: %llu", &wb) == 1)
+                            continue;
+                    }
+                    fclose(fio);
+                }
+                buf[count].read_bytes = rb;
+                buf[count].write_bytes = wb;
                 buf[count].utime = utime;
                 buf[count].stime = stime;
                 buf[count].cpu_usage = usage;

--- a/src/ui.c
+++ b/src/ui.c
@@ -65,6 +65,8 @@ enum column_id {
     COL_CPUP,
     COL_TIME,
     COL_START,
+    COL_READ,
+    COL_WRITE,
     COL_COUNT
 };
 
@@ -94,7 +96,9 @@ static struct column_def columns[COL_COUNT] = {
     {COL_CPU,   "CPU",     3, 0, 1,11},
     {COL_CPUP,  "CPU%",    6, 0, 1,12},
     {COL_TIME,  "TIME",    8, 0, 1,13},
-    {COL_START, "START",   8, 1, 1,14}
+    {COL_START, "START",   8, 1, 1,14},
+    {COL_READ,  "READ",    8, 0, 0,15},
+    {COL_WRITE, "WRITE",   8, 0, 0,16}
 };
 
 void ui_list_fields(void) {
@@ -446,6 +450,18 @@ static void draw_process_row(int row, const struct process_info *p) {
             mvprintw(row, x, columns[i].left ? "%-*s" : "%*s",
                      columns[i].width, p->start_time);
             break;
+        case COL_READ: {
+            double rb = scale_kb(p->read_bytes / 1024ULL, proc_unit);
+            mvprintw(row, x, columns[i].left ? "%-*.1f" : "%*.1f",
+                     columns[i].width, rb);
+            break;
+        }
+        case COL_WRITE: {
+            double wb = scale_kb(p->write_bytes / 1024ULL, proc_unit);
+            mvprintw(row, x, columns[i].left ? "%-*.1f" : "%*.1f",
+                     columns[i].width, wb);
+            break;
+        }
         default:
             break;
         }
@@ -518,7 +534,7 @@ static void field_manager(void) {
 }
 
 static void show_help(void) {
-    const int h = 41;
+    const int h = 42;
     const int w = 52;
     int startx = COLS > w ? (COLS - w) / 2 : 0;
     if (startx < 0)
@@ -561,10 +577,11 @@ static void show_help(void) {
     mvwprintw(win, 32, 2, "f       Field manager (toggle columns)");
     mvwprintw(win, 33, 2, "n       Set entry limit");
     mvwprintw(win, 34, 2, "W       Save config");
-    mvwprintw(win, 35, 2, "UP/DOWN  Scroll one line");
-    mvwprintw(win, 36, 2, "PgUp/PgDn Scroll a page");
-    mvwprintw(win, 37, 2, "SPACE    Pause/resume");
-    mvwprintw(win, 38, 2, "h       Show this help");
+    mvwprintw(win, 35, 2, "READ/WRITE columns show disk I/O");
+    mvwprintw(win, 36, 2, "UP/DOWN  Scroll one line");
+    mvwprintw(win, 37, 2, "PgUp/PgDn Scroll a page");
+    mvwprintw(win, 38, 2, "SPACE    Pause/resume");
+    mvwprintw(win, 39, 2, "h       Show this help");
     mvwprintw(win, h - 2, 2, "Press any key to return");
     wrefresh(win);
     nodelay(stdscr, FALSE);


### PR DESCRIPTION
## Summary
- extend `process_info` with `read_bytes` and `write_bytes`
- parse `/proc/[pid]/io` data in `list_processes`
- add READ and WRITE columns and support toggling them
- document new statistics in README and help screen

## Testing
- `make WITH_UI=1`
- `./vtop --list-fields`
- `./vtop -b 1 -n 1`

------
https://chatgpt.com/codex/tasks/task_e_685dbf7b3eb08324b3aa9dd8d04e586c