### PR TITLE
Add kernel thread hiding option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The `--list-fields` option prints all available column names and exits.
 The `-a`/`--cmdline` flag shows the full command line instead of the short
 command name.
 Use `-i`/`--hide-idle` to start with idle processes hidden.
+Use `--hide-kthreads` to hide kernel threads whose names begin with `[`.
 Use `-H`/`--threads` to show individual threads instead of processes.
 Use `--irix` to display CPU usage relative to a single CPU.
 Use `--per-cpu` to show per-core CPU usage by default.
@@ -79,6 +80,7 @@ Additional shortcuts:
 - Press `c` to toggle per-core CPU usage display.
 - Press `a` to toggle between the short command name and the full command line.
 - Press `H` to toggle thread view (show individual threads).
+- Press `K` to hide or show kernel threads.
 - Press `i` to hide or show processes with zero CPU usage.
 - Press `g` to filter by process state (e.g., `R` for running).
 - Press `Z` to cycle through color schemes.

--- a/include/proc.h
+++ b/include/proc.h
@@ -137,6 +137,10 @@ int get_thread_mode(void);
 void set_show_idle(int on);
 int get_show_idle(void);
 
+/* hide kernel threads */
+void set_hide_kthreads(int on);
+int get_hide_kthreads(void);
+
 /* accumulate child CPU time in cpu_time */
 void set_show_accum_time(int on);
 int get_show_accum_time(void);

--- a/include/ui.h
+++ b/include/ui.h
@@ -37,6 +37,7 @@ enum mem_unit next_mem_unit(enum mem_unit unit);
 void ui_set_show_full_cmd(int on);
 void ui_set_show_idle(int on);
 void ui_set_show_cores(int on);
+void ui_set_hide_kthreads(int on);
 /* Load configuration from ~/.vtoprc if available. The delay and sort
  * parameters are updated with the loaded values. */
 int ui_load_config(unsigned int *delay_ms, enum sort_field *sort);

--- a/src/main.c
+++ b/src/main.c
@@ -45,6 +45,7 @@ static void usage(const char *prog) {
     printf("  -w, --width COLS  Override screen width in columns\n");
     printf("  -a, --cmdline     Display the full command line by default\n");
     printf("  -i, --hide-idle   Hide processes with zero CPU usage\n");
+    printf("      --hide-kthreads Hide kernel threads\n");
     printf("  -H, --threads     Show individual threads instead of processes\n");
     printf("      --irix        Do not scale CPU%% by number of CPUs\n");
     printf("      --per-cpu     Show per-core CPU usage\n");
@@ -178,6 +179,7 @@ int main(int argc, char *argv[]) {
         {"width", required_argument, NULL, 'w'},
         {"cmdline", no_argument, NULL, 'a'},
         {"hide-idle", no_argument, NULL, 'i'},
+        {"hide-kthreads", no_argument, NULL, 5},
         {"threads", no_argument, NULL, 'H'},
 #ifdef WITH_UI
         {"list-fields", no_argument, NULL, 2},
@@ -219,6 +221,12 @@ int main(int argc, char *argv[]) {
                 set_state_filter(optarg[0]);
             else
                 set_state_filter('\0');
+            break;
+        case 5:
+            set_hide_kthreads(1);
+#ifdef WITH_UI
+            ui_set_hide_kthreads(1);
+#endif
             break;
         case '1':
 #ifdef WITH_UI

--- a/src/proc.c
+++ b/src/proc.c
@@ -37,6 +37,7 @@ static int sort_descending;
 /* show threads instead of processes */
 static int thread_mode;
 static int show_idle = 1;
+static int hide_kthreads;
 static int show_accum_time;
 static int cpu_irix_mode;
 static char state_filter;
@@ -49,6 +50,9 @@ int get_thread_mode(void) { return thread_mode; }
 
 void set_show_idle(int on) { show_idle = on != 0; }
 int get_show_idle(void) { return show_idle; }
+
+void set_hide_kthreads(int on) { hide_kthreads = on != 0; }
+int get_hide_kthreads(void) { return hide_kthreads; }
 
 void set_show_accum_time(int on) { show_accum_time = on != 0; }
 int get_show_accum_time(void) { return show_accum_time; }
@@ -105,6 +109,8 @@ size_t get_cpu_core_count(void) { return core_count; }
 const struct cpu_core_stats *get_cpu_core_stats(void) { return core_stats; }
 
 static int match_filter(int pid, const char *name, const char *user, char state) {
+    if (hide_kthreads && name && name[0] == '[')
+        return 0;
     if (pid_list_count > 0) {
         int found = 0;
         for (size_t i = 0; i < pid_list_count; i++) {

--- a/src/ui.c
+++ b/src/ui.c
@@ -24,6 +24,7 @@ static int show_cores;
 static int show_full_cmd;
 static int show_threads;
 static int show_idle = 1;
+static int hide_kthreads;
 struct color_scheme {
     short sort;
     short running;
@@ -137,6 +138,8 @@ void ui_set_show_idle(int on) { show_idle = on != 0; }
 
 void ui_set_show_cores(int on) { show_cores = on != 0; }
 
+void ui_set_hide_kthreads(int on) { hide_kthreads = on != 0; }
+
 static void apply_color_scheme(void) {
     if (!has_colors())
         return;
@@ -194,6 +197,8 @@ int ui_load_config(unsigned int *delay_ms, enum sort_field *sort) {
             show_threads = atoi(val);
         } else if (strcmp(key, "show_idle") == 0) {
             show_idle = atoi(val);
+        } else if (strcmp(key, "hide_kthreads") == 0) {
+            hide_kthreads = atoi(val);
         } else if (strcmp(key, "show_forest") == 0) {
             show_forest = atoi(val);
         } else if (strcmp(key, "show_cpu_summary") == 0) {
@@ -268,6 +273,7 @@ int ui_save_config(unsigned int delay_ms, enum sort_field sort) {
     fprintf(fp, "show_full_cmd=%d\n", show_full_cmd);
     fprintf(fp, "show_threads=%d\n", show_threads);
     fprintf(fp, "show_idle=%d\n", show_idle);
+    fprintf(fp, "hide_kthreads=%d\n", hide_kthreads);
     fprintf(fp, "show_forest=%d\n", show_forest);
     fprintf(fp, "show_cpu_summary=%d\n", show_cpu_summary);
     fprintf(fp, "show_mem_summary=%d\n", show_mem_summary);
@@ -564,24 +570,25 @@ static void show_help(void) {
     mvwprintw(win, 19, 2, "c       Toggle per-core view");
     mvwprintw(win, 20, 2, "a       Toggle full command");
     mvwprintw(win, 21, 2, "H       Toggle thread view");
-    mvwprintw(win, 22, 2, "i       Toggle idle processes");
-    mvwprintw(win, 23, 2, "V       Toggle process tree");
-    mvwprintw(win, 24, 2, "Z       Cycle color scheme");
-    mvwprintw(win, 25, 2, "x       Toggle sort highlight");
-    mvwprintw(win, 26, 2, "b       Toggle bold text");
-    mvwprintw(win, 27, 2, "S       Toggle cumulative time");
-    mvwprintw(win, 28, 2, "I       Toggle Irix mode");
-    mvwprintw(win, 29, 2, "E       Cycle memory units");
-    mvwprintw(win, 30, 2, "t       Toggle CPU summary");
-    mvwprintw(win, 31, 2, "m       Toggle memory summary");
-    mvwprintw(win, 32, 2, "f       Field manager (toggle columns)");
-    mvwprintw(win, 33, 2, "n       Set entry limit");
-    mvwprintw(win, 34, 2, "W       Save config");
-    mvwprintw(win, 35, 2, "READ/WRITE columns show disk I/O");
-    mvwprintw(win, 36, 2, "UP/DOWN  Scroll one line");
-    mvwprintw(win, 37, 2, "PgUp/PgDn Scroll a page");
-    mvwprintw(win, 38, 2, "SPACE    Pause/resume");
-    mvwprintw(win, 39, 2, "h       Show this help");
+    mvwprintw(win, 22, 2, "K       Toggle kernel threads");
+    mvwprintw(win, 23, 2, "i       Toggle idle processes");
+    mvwprintw(win, 24, 2, "V       Toggle process tree");
+    mvwprintw(win, 25, 2, "Z       Cycle color scheme");
+    mvwprintw(win, 26, 2, "x       Toggle sort highlight");
+    mvwprintw(win, 27, 2, "b       Toggle bold text");
+    mvwprintw(win, 28, 2, "S       Toggle cumulative time");
+    mvwprintw(win, 29, 2, "I       Toggle Irix mode");
+    mvwprintw(win, 30, 2, "E       Cycle memory units");
+    mvwprintw(win, 31, 2, "t       Toggle CPU summary");
+    mvwprintw(win, 32, 2, "m       Toggle memory summary");
+    mvwprintw(win, 33, 2, "f       Field manager (toggle columns)");
+    mvwprintw(win, 34, 2, "n       Set entry limit");
+    mvwprintw(win, 35, 2, "W       Save config");
+    mvwprintw(win, 36, 2, "READ/WRITE columns show disk I/O");
+    mvwprintw(win, 37, 2, "UP/DOWN  Scroll one line");
+    mvwprintw(win, 38, 2, "PgUp/PgDn Scroll a page");
+    mvwprintw(win, 39, 2, "SPACE    Pause/resume");
+    mvwprintw(win, 40, 2, "h       Show this help");
     mvwprintw(win, h - 2, 2, "Press any key to return");
     wrefresh(win);
     nodelay(stdscr, FALSE);
@@ -705,6 +712,7 @@ int run_ui(unsigned int delay_ms, enum sort_field sort,
     show_threads = get_thread_mode();
     set_thread_mode(show_threads);
     set_show_idle(show_idle);
+    set_hide_kthreads(hide_kthreads);
     unsigned int interval = delay_ms;
     if (interval < MIN_DELAY_MS)
         interval = MIN_DELAY_MS;
@@ -995,6 +1003,9 @@ int run_ui(unsigned int delay_ms, enum sort_field sort,
         } else if (ch == 'H') {
             show_threads = !show_threads;
             set_thread_mode(show_threads);
+        } else if (ch == 'K') {
+            hide_kthreads = !hide_kthreads;
+            set_hide_kthreads(hide_kthreads);
         } else if (ch == 'i') {
             show_idle = !show_idle;
             set_show_idle(show_idle);

--- a/vtopdoc.md
+++ b/vtopdoc.md
@@ -74,6 +74,7 @@ monitoring tools without requiring additional dependencies.
 - `-a`/`--cmdline` &mdash; Show the full command line instead of just the
   process name.
 - `-i`/`--hide-idle` &mdash; Do not list tasks with zero CPU usage.
+- `--hide-kthreads` &mdash; Hide kernel threads (commands starting with `[`).
 - `--irix` &mdash; Display per-process CPU usage relative to one CPU.
 - `-u USER`, `-U USER` &mdash; Show only processes owned by `USER`.
 - `-C STR`, `--command-filter STR` &mdash; Show only tasks whose command
@@ -107,6 +108,7 @@ Process management shortcuts are also available:
 - `r` &ndash; prompt for a PID and new nice value to adjust process priority.
 - `c` &ndash; toggle per-core CPU usage display.
 - `a` &ndash; toggle between the short name and full command line.
+- `K` &ndash; toggle display of kernel threads.
 - `S` &ndash; toggle cumulative CPU time display.
 - `g` &ndash; filter processes by state (enter a letter like `R`).
 - `I` &ndash; toggle Irix mode (CPU usage of each task not divided by CPU count).


### PR DESCRIPTION
## Summary
- add `hide_kthreads` flag in process layer
- skip bracketed commands when hiding kernel threads
- expose new option through CLI, config, and UI
- update help text and docs

## Testing
- `make clean >/tmp/make_clean.log && make WITH_UI=1 >/tmp/make.log && tail -n 20 /tmp/make.log`

------
https://chatgpt.com/codex/tasks/task_e_685e19835e088324a7df008148c3bdf6